### PR TITLE
static const in generated gemmini_params

### DIFF
--- a/src/main/scala/gemmini/GemminiConfigs.scala
+++ b/src/main/scala/gemmini/GemminiConfigs.scala
@@ -158,8 +158,8 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data](
     // Datatype of the systolic array
     val limits = limitsOfDataType(inputType)
     header ++= s"typedef ${c_type(inputType)} elem_t;\n"
-    header ++= s"elem_t elem_t_max = ${limits._2};\n"
-    header ++= s"elem_t elem_t_min = ${limits._1};\n"
+    header ++= s"static const elem_t elem_t_max = ${limits._2};\n"
+    header ++= s"static const elem_t elem_t_min = ${limits._1};\n"
     header ++= s"typedef ${c_type(accType)} acc_t;\n"
     header ++= s"typedef ${full_c_type(inputType)} full_t;\n\n"
 


### PR DESCRIPTION
Otherwise if gemmini_param.h is included in a static library as well as an application that uses that static library, the linker doesn't like it.