### PR TITLE
added cisc frontend

### DIFF
--- a/src/main/scala/gemmini/CmdFSM.scala
+++ b/src/main/scala/gemmini/CmdFSM.scala
@@ -166,12 +166,12 @@ class CmdFSM[T <: Data: Arithmetic, U <: Data]
         addr_d := rs2
         addr_cd_valid := true.B
       }
-      .elsewhen (funct === SIZE0) {
+      .elsewhen (funct === SIZE_MN) {
         m := rs1
         n := rs2
         size0_valid := true.B
       }
-      .elsewhen (funct === SIZE1) {
+      .elsewhen (funct === SIZE_K) {
         k := rs1
         size1_valid := true.B
       }

--- a/src/main/scala/gemmini/CmdFSM.scala
+++ b/src/main/scala/gemmini/CmdFSM.scala
@@ -1,0 +1,198 @@
+//===========================================================================
+// Command FSM
+// * Receive RoCC commands
+// * Check validity of configuration data
+// * Hand off to Tiling on COMPUTE requests
+//===========================================================================
+package gemmini
+
+import chisel3._
+import chisel3.util._
+import chisel3.experimental._
+import freechips.rocketchip.config._
+import freechips.rocketchip.rocket._
+import freechips.rocketchip.tile._
+import GemminiISA._
+
+class CmdFSM[T <: Data: Arithmetic, U <: Data]
+  (config: GemminiArrayConfig[T,U])(implicit val p: Parameters)
+  extends Module with HasCoreParameters {
+  import config._
+  //==========================================================================
+  // module ports
+  //==========================================================================
+  val io = IO(new Bundle {
+    val cmd         = Flipped(Decoupled(new RoCCCommand))
+    val tiler       = Decoupled(new TilerCmd(LOG2_OTYPE_BITS))
+    val flush_retry = Output(Bool())
+    val flush_skip  = Output(Bool())
+    val busy        = Output(Bool())
+  });
+
+  //==========================================================================
+  // FSM states
+  //==========================================================================
+  val (s_LISTENING :: s_EX_PENDING :: s_ERROR :: Nil) = Enum(3)
+  val state = RegInit(s_LISTENING)
+
+  //==========================================================================
+  // local state registers
+  //==========================================================================
+  val m              = RegInit(0.U(32.W))
+  val n              = RegInit(0.U(32.W))
+  val k              = RegInit(0.U(32.W))
+  val addr_a         = RegInit(0.U(xLen.W))
+  val addr_b         = RegInit(0.U(xLen.W))
+  val addr_c         = RegInit(0.U(xLen.W))
+  val addr_d         = RegInit(0.U(xLen.W))
+  val in_rshift      = RegInit(0.U(log2Up(accType.getWidth).W))
+  val acc_rshift     = RegInit(0.U(log2Up(accType.getWidth).W))
+  val relu6_lshift   = RegInit(0.U(log2Up(accType.getWidth).W))
+  val activation     = RegInit(0.U(2.W))
+  val repeating_bias = RegInit(0.U(1.W))
+
+  // Valid fields
+  val addr_ab_valid = RegInit(false.B)
+  val addr_cd_valid = RegInit(false.B)
+  val size0_valid = RegInit(false.B)
+  val size1_valid = RegInit(false.B)
+  val config_ex_valid = RegInit(false.B)
+  val bias_valid = RegInit(false.B)
+
+  // pass CSR status bits to tiler (TODO: fix this api)
+  val status = Reg(new MStatus)
+  status := DontCare
+
+  //==========================================================================
+  // Combinational Output Defaults 
+  //==========================================================================
+  io.cmd.ready         := false.B
+  io.tiler.valid       := false.B
+  io.tiler.bits.status := status
+  io.flush_retry       := false.B
+  io.flush_skip        := false.B
+
+  io.tiler.bits.m              := m
+  io.tiler.bits.n              := n
+  io.tiler.bits.k              := k
+  io.tiler.bits.addr_a         := addr_a
+  io.tiler.bits.addr_b         := addr_b
+  io.tiler.bits.addr_c         := addr_c
+  io.tiler.bits.addr_d         := addr_d
+  io.tiler.bits.in_rshift      := in_rshift
+  io.tiler.bits.acc_rshift     := acc_rshift
+  io.tiler.bits.relu6_lshift   := relu6_lshift
+  io.tiler.bits.activation     := activation
+  io.tiler.bits.repeating_bias := repeating_bias
+
+  // we block if we have accepted the COMPUTE_ALL command, but the tiler has
+  // not started executing it yet.
+  io.busy := (state === s_EX_PENDING)
+
+  //==========================================================================
+  // FSM 
+  //==========================================================================
+  def reset_and_listen(): Unit = {
+    // Reset all data-validity
+    addr_ab_valid := false.B
+    addr_cd_valid := false.B
+    size0_valid := false.B
+    size1_valid := false.B
+    config_ex_valid := false.B
+    bias_valid := false.B
+    // And go back to listening for commands
+    state := s_LISTENING
+  }
+
+  when (state === s_EX_PENDING) {
+    // Pending s_EX ongoing
+    // Wait for tiling/ execution to complete,
+    // let any further commands queue up
+    io.tiler.valid := true.B
+    when (io.tiler.fire()) {
+      state := s_LISTENING
+    }
+  }.elsewhen (state === s_ERROR) {
+    // In s_ERROR state - only update based on RESET commands
+    io.cmd.ready := true.B
+    when (io.cmd.fire()) {
+      val cmd = io.cmd.bits
+      val funct = cmd.inst.funct
+      when (funct === RESET) {
+        reset_and_listen()
+      } // All other commands are ignored
+    }
+  }.otherwise { // s_LISTENING State
+    io.cmd.ready := true.B
+    when (io.cmd.fire()) {
+      val cmd = io.cmd.bits
+      val funct = cmd.inst.funct
+      val rs1 = cmd.rs1
+      val rs2 = cmd.rs2
+
+      // always update status bits on a successful RoCC command
+      status := cmd.status
+
+      // Execute command
+      when (funct === FLUSH_CMD) {
+        val skip = cmd.rs1(0)
+        io.flush_retry := !skip
+        io.flush_skip  := skip
+      }
+      .elsewhen (funct === COMPUTE_CISC) {
+        // Signal to the Tiler, and move to our EXEC state
+        // FIXME: check all valid
+        io.tiler.valid := true.B
+        when (io.tiler.fire()) {
+          state := s_LISTENING
+        }.otherwise {
+          state := s_EX_PENDING
+        }
+      }
+      .elsewhen (funct === CISC_CONFIG) {
+        activation := rs1(4,3)
+        acc_rshift := rs1(63,32)
+        in_rshift := rs2(31,0)
+        relu6_lshift := rs2(63,32)
+        config_ex_valid := true.B
+      }
+      .elsewhen (funct === ADDR_AB) {
+        addr_a := rs1
+        addr_b := rs2
+        addr_ab_valid := true.B
+      }
+      .elsewhen (funct === ADDR_CD) {
+        addr_c := rs1
+        addr_d := rs2
+        addr_cd_valid := true.B
+      }
+      .elsewhen (funct === SIZE0) {
+        m := rs1
+        n := rs2
+        size0_valid := true.B
+      }
+      .elsewhen (funct === SIZE1) {
+        k := rs1
+        size1_valid := true.B
+      }
+      .elsewhen (funct === RPT_BIAS) {
+        repeating_bias := rs1(0).asBool
+        bias_valid := true.B
+      }
+      .elsewhen (funct === RESET) {
+        reset_and_listen()
+      }
+      .otherwise {
+        // Invalid command type
+        // FIXME: error-cause setup
+        state := s_ERROR
+      }
+    }
+  }
+}
+
+object CmdFSM {
+  def apply[T <: Data: Arithmetic, U <: Data]
+    (config: GemminiArrayConfig[T,U])(implicit p: Parameters)
+      = Module(new CmdFSM(config))
+}

--- a/src/main/scala/gemmini/Controller.scala
+++ b/src/main/scala/gemmini/Controller.scala
@@ -134,8 +134,8 @@ class GemminiModule[T <: Data: Arithmetic, U <: Data]
   val is_cisc_funct = (funct === CISC_CONFIG) ||
                       (funct === ADDR_AB) ||
                       (funct === ADDR_CD) ||
-                      (funct === SIZE0) ||
-                      (funct === SIZE1) ||
+                      (funct === SIZE_MN) ||
+                      (funct === SIZE_K) ||
                       (funct === RPT_BIAS) ||
                       (funct === RESET) ||
                       (funct === COMPUTE_CISC)

--- a/src/main/scala/gemmini/GemminiConfigs.scala
+++ b/src/main/scala/gemmini/GemminiConfigs.scala
@@ -76,76 +76,76 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data](
   //==========================================================================
   // sanity check mesh size
   //==========================================================================
-  def BLOCK_ROWS = tileRows * meshRows
-  def BLOCK_COLS = tileColumns * meshColumns
+  val BLOCK_ROWS = tileRows * meshRows
+  val BLOCK_COLS = tileColumns * meshColumns
   require(BLOCK_ROWS == BLOCK_COLS, "BLOCK_ROWS != BLOCK_COLS!")
 
-  def DIM             = BLOCK_ROWS
-  def LOG2_DIM        = log2Up(DIM)
-  def LOG2_DIM_COUNT  = log2Up(DIM + 1)
+  val DIM             = BLOCK_ROWS
+  val LOG2_DIM        = log2Up(DIM)
+  val LOG2_DIM_COUNT  = log2Up(DIM + 1)
   require(DIM >= 2, "the systolic array must have DIM of at least 2")
 
   //==========================================================================
   // cisc-gemmini miscellaneous constants (some redundant with above)
   //==========================================================================
-  def ROB_ENTRIES      = rob_entries
-  def LOG2_ROB_ENTRIES = log2Up(rob_entries)
+  val ROB_ENTRIES      = rob_entries
+  val LOG2_ROB_ENTRIES = log2Up(rob_entries)
 
   //==========================================================================
   // cisc-gemmini hardware-specific compile-time global constants
   //==========================================================================
 
-  def ITYPE_BITS       = inputType.getWidth
-  def ITYPE_BYTES      = (inputType.getWidth+7) / 8
-  def LOG2_ITYPE_BYTES = if(ITYPE_BYTES <= 1) 0 else log2Up(ITYPE_BYTES)
+  val ITYPE_BITS       = inputType.getWidth
+  val ITYPE_BYTES      = (inputType.getWidth+7) / 8
+  val LOG2_ITYPE_BYTES = if(ITYPE_BYTES <= 1) 0 else log2Up(ITYPE_BYTES)
 
-  def OTYPE_BITS       = accType.getWidth
-  def LOG2_OTYPE_BITS  = log2Up(OTYPE_BITS)
-  def OTYPE_BYTES      = (accType.getWidth+7) / 8
-  def LOG2_OTYPE_BYTES = if(OTYPE_BYTES <= 1) 0 else log2Up(OTYPE_BYTES)
+  val OTYPE_BITS       = accType.getWidth
+  val LOG2_OTYPE_BITS  = log2Up(OTYPE_BITS)
+  val OTYPE_BYTES      = (accType.getWidth+7) / 8
+  val LOG2_OTYPE_BYTES = if(OTYPE_BYTES <= 1) 0 else log2Up(OTYPE_BYTES)
 
-  def SP_BANKS        = sp_banks
-  def SP_BANK_ROWS    = sp_bank_entries
-  def SP_ROWS         = SP_BANKS * SP_BANK_ROWS
-  def LOG2_SP_ROWS    = log2Up(SP_ROWS)
+  val SP_BANKS        = sp_banks
+  val SP_BANK_ROWS    = sp_bank_entries
+  val SP_ROWS         = SP_BANKS * SP_BANK_ROWS
+  val LOG2_SP_ROWS    = log2Up(SP_ROWS)
 
-  def ACC_BANKS       = acc_banks
-  def ACC_BANK_ROWS   = acc_bank_entries
-  def ACC_ROWS        = ACC_BANKS * ACC_BANK_ROWS
-  def LOG2_ACC_ROWS   = log2Up(ACC_ROWS)
+  val ACC_BANKS       = acc_banks
+  val ACC_BANK_ROWS   = acc_bank_entries
+  val ACC_ROWS        = ACC_BANKS * ACC_BANK_ROWS
+  val LOG2_ACC_ROWS   = log2Up(ACC_ROWS)
 
-  def MNK_BYTES                   = Int.MaxValue / DIM  // TODO: upper bound?
-  def LOG2_MNK_BYTES              = log2Up(MNK_BYTES)
-  def MNK_BYTES_PER_TILE_ROW      = MNK_BYTES * DIM
-  def LOG2_MNK_BYTES_PER_TILE_ROW = log2Up(MNK_BYTES_PER_TILE_ROW)
-  def TILE_IDX                    = MNK_BYTES / (DIM / 8)
-  def LOG2_TILE_IDX               = log2Up(TILE_IDX)
+  val MNK_BYTES                   = Int.MaxValue / DIM  // TODO: upper bound?
+  val LOG2_MNK_BYTES              = log2Up(MNK_BYTES)
+  val MNK_BYTES_PER_TILE_ROW      = MNK_BYTES * DIM
+  val LOG2_MNK_BYTES_PER_TILE_ROW = log2Up(MNK_BYTES_PER_TILE_ROW)
+  val TILE_IDX                    = MNK_BYTES / (DIM / 8)
+  val LOG2_TILE_IDX               = log2Up(TILE_IDX)
 
   //--------------------------------------------------------------------------
-  def I_TILE_BYTE_WIDTH = DIM * ((inputType.getWidth+7) / 8)
-  def O_TILE_BYTE_WIDTH = DIM * ((accType.getWidth+7) / 8)
-  def I_TILE_BYTE_WIDTH_LOG2 = log2Up(I_TILE_BYTE_WIDTH)
-  def O_TILE_BYTE_WIDTH_LOG2 = log2Up(O_TILE_BYTE_WIDTH)
+  val I_TILE_BYTE_WIDTH = DIM * ((inputType.getWidth+7) / 8)
+  val O_TILE_BYTE_WIDTH = DIM * ((accType.getWidth+7) / 8)
+  val I_TILE_BYTE_WIDTH_LOG2 = log2Up(I_TILE_BYTE_WIDTH)
+  val O_TILE_BYTE_WIDTH_LOG2 = log2Up(O_TILE_BYTE_WIDTH)
   require(pow(2,I_TILE_BYTE_WIDTH_LOG2) == I_TILE_BYTE_WIDTH,
     s"I_TILE_BYTE_WIDTH is not power of 2: $I_TILE_BYTE_WIDTH")
   require(pow(2,O_TILE_BYTE_WIDTH_LOG2) == O_TILE_BYTE_WIDTH,
     s"O_TILE_BYTE_WIDTH is not power of 2: $O_TILE_BYTE_WIDTH")
 
-  def GBL_B_SP_ROW_ADDR_1 = (SP_BANKS * SP_BANK_ROWS) - 2*DIM
-  def GBL_B_SP_ROW_ADDR_2 = (SP_BANKS * SP_BANK_ROWS) - 1*DIM
+  val GBL_B_SP_ROW_ADDR_1 = (SP_BANKS * SP_BANK_ROWS) - 2*DIM
+  val GBL_B_SP_ROW_ADDR_2 = (SP_BANKS * SP_BANK_ROWS) - 1*DIM
 
-  def USABLE_SP_TILES = (SP_ROWS / DIM) - 2
-  def TOTAL_ACC_TILES = (ACC_ROWS / DIM)
-  def SQRT_ACC_TILES = sqrt(TOTAL_ACC_TILES).toInt
+  val USABLE_SP_TILES = (SP_ROWS / DIM) - 2
+  val TOTAL_ACC_TILES = (ACC_ROWS / DIM)
+  val SQRT_ACC_TILES = sqrt(TOTAL_ACC_TILES).toInt
   assert(USABLE_SP_TILES >= TOTAL_ACC_TILES, 
     s"SP_TILES($USABLE_SP_TILES) + 2 < ACC_TILES($TOTAL_ACC_TILES)")
 
   // prioritize sizes that cause the output-group to be further from square
-  def OG_HEIGHT_MAP = (1 to TOTAL_ACC_TILES).sortWith((h1, h2) => {
+  val OG_HEIGHT_MAP = (1 to TOTAL_ACC_TILES).sortWith((h1, h2) => {
     (h1 - SQRT_ACC_TILES).abs > (h2 - SQRT_ACC_TILES).abs
   })
 
-  def BYTE_ROWS_PER_TILE = DIM
+  val BYTE_ROWS_PER_TILE = DIM
 
   //==========================================================================
   // other stuff

--- a/src/main/scala/gemmini/GemminiConfigs.scala
+++ b/src/main/scala/gemmini/GemminiConfigs.scala
@@ -1,5 +1,6 @@
 package gemmini
 
+import scala.math.{pow,sqrt}
 import chisel3._
 import chisel3.util._
 
@@ -71,6 +72,84 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data](
   val mvin_rows_bits = log2Up(meshRows * tileRows + 1)
   val mvout_len_bits = log2Up(meshColumns * tileColumns + 1)
   val mvout_rows_bits = log2Up(meshRows * tileRows + 1)
+
+  //==========================================================================
+  // sanity check mesh size
+  //==========================================================================
+  def BLOCK_ROWS = tileRows * meshRows
+  def BLOCK_COLS = tileColumns * meshColumns
+  require(BLOCK_ROWS == BLOCK_COLS, "BLOCK_ROWS != BLOCK_COLS!")
+
+  def DIM             = BLOCK_ROWS
+  def LOG2_DIM        = log2Up(DIM)
+  def LOG2_DIM_COUNT  = log2Up(DIM + 1)
+  require(DIM >= 2, "the systolic array must have DIM of at least 2")
+
+  //==========================================================================
+  // cisc-gemmini miscellaneous constants (some redundant with above)
+  //==========================================================================
+  def ROB_ENTRIES      = rob_entries
+  def LOG2_ROB_ENTRIES = log2Up(rob_entries)
+
+  //==========================================================================
+  // cisc-gemmini hardware-specific compile-time global constants
+  //==========================================================================
+
+  def ITYPE_BITS       = inputType.getWidth
+  def ITYPE_BYTES      = (inputType.getWidth+7) / 8
+  def LOG2_ITYPE_BYTES = if(ITYPE_BYTES <= 1) 0 else log2Up(ITYPE_BYTES)
+
+  def OTYPE_BITS       = accType.getWidth
+  def LOG2_OTYPE_BITS  = log2Up(OTYPE_BITS)
+  def OTYPE_BYTES      = (accType.getWidth+7) / 8
+  def LOG2_OTYPE_BYTES = if(OTYPE_BYTES <= 1) 0 else log2Up(OTYPE_BYTES)
+
+  def SP_BANKS        = sp_banks
+  def SP_BANK_ROWS    = sp_bank_entries
+  def SP_ROWS         = SP_BANKS * SP_BANK_ROWS
+  def LOG2_SP_ROWS    = log2Up(SP_ROWS)
+
+  def ACC_BANKS       = acc_banks
+  def ACC_BANK_ROWS   = acc_bank_entries
+  def ACC_ROWS        = ACC_BANKS * ACC_BANK_ROWS
+  def LOG2_ACC_ROWS   = log2Up(ACC_ROWS)
+
+  def MNK_BYTES                   = Int.MaxValue / DIM  // TODO: upper bound?
+  def LOG2_MNK_BYTES              = log2Up(MNK_BYTES)
+  def MNK_BYTES_PER_TILE_ROW      = MNK_BYTES * DIM
+  def LOG2_MNK_BYTES_PER_TILE_ROW = log2Up(MNK_BYTES_PER_TILE_ROW)
+  def TILE_IDX                    = MNK_BYTES / (DIM / 8)
+  def LOG2_TILE_IDX               = log2Up(TILE_IDX)
+
+  //--------------------------------------------------------------------------
+  def I_TILE_BYTE_WIDTH = DIM * ((inputType.getWidth+7) / 8)
+  def O_TILE_BYTE_WIDTH = DIM * ((accType.getWidth+7) / 8)
+  def I_TILE_BYTE_WIDTH_LOG2 = log2Up(I_TILE_BYTE_WIDTH)
+  def O_TILE_BYTE_WIDTH_LOG2 = log2Up(O_TILE_BYTE_WIDTH)
+  require(pow(2,I_TILE_BYTE_WIDTH_LOG2) == I_TILE_BYTE_WIDTH,
+    s"I_TILE_BYTE_WIDTH is not power of 2: $I_TILE_BYTE_WIDTH")
+  require(pow(2,O_TILE_BYTE_WIDTH_LOG2) == O_TILE_BYTE_WIDTH,
+    s"O_TILE_BYTE_WIDTH is not power of 2: $O_TILE_BYTE_WIDTH")
+
+  def GBL_B_SP_ROW_ADDR_1 = (SP_BANKS * SP_BANK_ROWS) - 2*DIM
+  def GBL_B_SP_ROW_ADDR_2 = (SP_BANKS * SP_BANK_ROWS) - 1*DIM
+
+  def USABLE_SP_TILES = (SP_ROWS / DIM) - 2
+  def TOTAL_ACC_TILES = (ACC_ROWS / DIM)
+  def SQRT_ACC_TILES = sqrt(TOTAL_ACC_TILES).toInt
+  assert(USABLE_SP_TILES >= TOTAL_ACC_TILES, 
+    s"SP_TILES($USABLE_SP_TILES) + 2 < ACC_TILES($TOTAL_ACC_TILES)")
+
+  // prioritize sizes that cause the output-group to be further from square
+  def OG_HEIGHT_MAP = (1 to TOTAL_ACC_TILES).sortWith((h1, h2) => {
+    (h1 - SQRT_ACC_TILES).abs > (h2 - SQRT_ACC_TILES).abs
+  })
+
+  def BYTE_ROWS_PER_TILE = DIM
+
+  //==========================================================================
+  // other stuff
+  //==========================================================================
 
   require(isPow2(sp_bank_entries), "each SRAM bank must have a power-of-2 rows, to simplify address calculations") // TODO remove this requirement
   require(sp_bank_entries % (meshRows * tileRows) == 0, "the number of rows in a bank must be a multiple of the dimensions of the systolic array")

--- a/src/main/scala/gemmini/GemminiISA.scala
+++ b/src/main/scala/gemmini/GemminiISA.scala
@@ -24,8 +24,8 @@ object GemminiISA {
   val CISC_CONFIG  = 10.U(7.W) // same as COMPUTE_AND_FLIP
   val ADDR_AB      = 11.U(7.W)
   val ADDR_CD      = 12.U(7.W)
-  val SIZE0        = 13.U(7.W)
-  val SIZE1        = 14.U(7.W)
+  val SIZE_MN      = 13.U(7.W)
+  val SIZE_K       = 14.U(7.W)
   val RPT_BIAS     = 15.U(7.W)
   val RESET        = 16.U(7.W)
   val COMPUTE_CISC = 17.U(7.W)

--- a/src/main/scala/gemmini/GemminiISA.scala
+++ b/src/main/scala/gemmini/GemminiISA.scala
@@ -17,4 +17,21 @@ object GemminiISA {
   val CONFIG_LOAD = 1.U
   val CONFIG_STORE = 2.U
   val CONFIG_EX = 0.U
+
+  //==========================================================================
+  // cisc-gemmini opcodes
+  //==========================================================================
+  val CISC_CONFIG  = 10.U(7.W) // same as COMPUTE_AND_FLIP
+  val ADDR_AB      = 11.U(7.W)
+  val ADDR_CD      = 12.U(7.W)
+  val SIZE0        = 13.U(7.W)
+  val SIZE1        = 14.U(7.W)
+  val RPT_BIAS     = 15.U(7.W)
+  val RESET        = 16.U(7.W)
+  val COMPUTE_CISC = 17.U(7.W)
+
+  //==========================================================================
+  // dataflow configuration
+  //==========================================================================
+  val GARBAGE_ADDR      = "hffffffff".U(32.W)
 }

--- a/src/main/scala/gemmini/MultiTailedQueue.scala
+++ b/src/main/scala/gemmini/MultiTailedQueue.scala
@@ -1,0 +1,48 @@
+package gemmini
+
+import chisel3._
+import chisel3.util._
+import Util._
+
+class MultiTailedQueue[T <: Data](gen: T, entries: Int, maxpush: Int) 
+  extends Module {
+  val io = IO(new Bundle {
+    val enq = new Bundle {
+      val ready = Output(UInt((log2Ceil(maxpush) + 1).W))
+      val bits = Input(Vec(maxpush, gen))
+      val push = Input(UInt((log2Ceil(maxpush) + 1).W))
+    }
+    val deq = Decoupled(gen)
+  })
+
+  val regs  = Reg(Vec(entries, gen))
+  val raddr = RegInit(0.U((log2Ceil(entries) max 1).W))
+  val waddr = RegInit(0.U((log2Ceil(entries) max 1).W))
+  val avail = RegInit(entries.U(log2Ceil(entries+1).W))
+
+  assert(maxpush >= 1)
+  assert(io.enq.ready <= avail)
+  assert(io.enq.push <= io.enq.ready)
+
+  // push interface
+  io.enq.ready := Mux(avail < maxpush.U, avail, maxpush.U)
+  for (i <- 0 until maxpush) {
+    when(io.enq.push > i.U) {
+      regs(wrappingAdd(waddr, i.U, entries)) := io.enq.bits(i)
+    }
+  }
+  waddr := wrappingAdd(waddr, io.enq.push, entries)
+
+  // pop interface
+  io.deq.bits := regs(raddr)
+  io.deq.valid := (avail < entries.U)
+  raddr := wrappingAdd(raddr, io.deq.fire(), entries)
+
+  // countgth calc
+  avail := avail - io.enq.push + io.deq.fire()
+}
+
+object MultiTailedQueue {
+  def apply[T <: Data](gen: T, entries: Int, maxpush: Int)
+    = new MultiTailedQueue(gen.cloneType, entries, maxpush)
+}

--- a/src/main/scala/gemmini/TilerController.scala
+++ b/src/main/scala/gemmini/TilerController.scala
@@ -1,0 +1,89 @@
+//===========================================================================
+// TilerController Implementation
+//===========================================================================
+package gemmini
+
+import chisel3._
+import chisel3.util._
+import chisel3.experimental._
+import freechips.rocketchip.config._
+import freechips.rocketchip.rocket._
+import freechips.rocketchip.tile._
+
+class TilerCmd(OTYPE_BITS_IDX: Int)
+  (implicit p: Parameters) extends CoreBundle {
+  val m              = UInt(32.W)
+  val n              = UInt(32.W)
+  val k              = UInt(32.W)
+  val addr_a         = UInt(xLen.W)
+  val addr_b         = UInt(xLen.W)
+  val addr_c         = UInt(xLen.W)
+  val addr_d         = UInt(xLen.W)
+  val in_rshift      = UInt(OTYPE_BITS_IDX.W)
+  val acc_rshift     = UInt(OTYPE_BITS_IDX.W)
+  val relu6_lshift   = UInt(OTYPE_BITS_IDX.W)
+  val activation     = UInt(2.W)
+  val repeating_bias = Bool()
+  val status         = new MStatus
+
+  override def cloneType: this.type =
+    (new TilerCmd(OTYPE_BITS_IDX)).asInstanceOf[this.type]
+}
+
+
+class TilerController[T <: Data: Arithmetic, U <: Data]
+  (config: GemminiArrayConfig[T,U])(implicit val p: Parameters) 
+  extends Module with HasCoreParameters {
+  import config._
+
+  //=========================================================================
+  // Interface
+  //=========================================================================
+  val io = IO(new Bundle {
+    val cmd_in = Flipped(Decoupled(new TilerCmd(LOG2_OTYPE_BITS)))
+    val issue = new Bundle {
+      val exec  = Decoupled(new GemminiCmd(ROB_ENTRIES))
+      val load  = Decoupled(new GemminiCmd(ROB_ENTRIES))
+      val store = Decoupled(new GemminiCmd(ROB_ENTRIES))
+    }
+    val completed = new Bundle {
+      val exec  = Flipped(Valid(UInt(LOG2_ROB_ENTRIES.W)))
+      val load  = Flipped(Decoupled(UInt(LOG2_ROB_ENTRIES.W)))
+      val store = Flipped(Decoupled(UInt(LOG2_ROB_ENTRIES.W)))
+    }
+    val busy = Output(Bool())
+  })
+
+  //=========================================================================
+  // dispatch incoming commands
+  //=========================================================================
+  val fsm = TilerFSM(config)
+  fsm.io.cmd_in <> io.cmd_in
+
+  val sched = TilerScheduler(config)
+  sched.io.cmd_in <> fsm.io.sched_out
+  io.issue.exec   <> sched.io.issue.exec
+  io.issue.load   <> sched.io.issue.load
+  io.issue.store  <> sched.io.issue.store
+
+  //=========================================================================
+  // arbitrate incoming completions
+  //=========================================================================
+  val arb = Module(new Arbiter(UInt(LOG2_ROB_ENTRIES.W), 3))
+  arb.io.in(0).valid := io.completed.exec.valid
+  arb.io.in(0).bits  := io.completed.exec.bits
+  arb.io.in(1)       <> io.completed.load
+  arb.io.in(2)       <> io.completed.store
+  sched.io.completed <> arb.io.out
+
+  //=========================================================================
+  // busy signal
+  //=========================================================================
+  io.busy := fsm.io.busy || sched.io.busy
+}
+
+object TilerController {
+  def apply[T <: Data: Arithmetic, U <: Data]
+    (config: GemminiArrayConfig[T,U])(implicit p: Parameters)
+      = Module(new TilerController(config))
+}

--- a/src/main/scala/gemmini/TilerFSM.scala
+++ b/src/main/scala/gemmini/TilerFSM.scala
@@ -9,6 +9,7 @@ import chisel3.experimental._
 import freechips.rocketchip.config._
 import freechips.rocketchip.tile._
 import GemminiISA._
+import Util.regwire
 
 class TilerFSM[T <: Data : Arithmetic, U <: Data]
   (config: GemminiArrayConfig[T,U])(implicit val p: Parameters) 
@@ -66,14 +67,6 @@ class TilerFSM[T <: Data : Arithmetic, U <: Data]
   //=========================================================================
   // Internal State
   //=========================================================================
-
-  // creates a Reg and the next-state Wire, and returns both
-  def regwire(bits: Int) = {
-    val wire = Wire(UInt(bits.W))
-    val reg = RegNext(wire)
-    wire := reg // default wire to read from reg
-    (reg, wire)
-  }
 
   //------------------------------------------------------------------------
   // input data-specific constants

--- a/src/main/scala/gemmini/TilerFSM.scala
+++ b/src/main/scala/gemmini/TilerFSM.scala
@@ -1,0 +1,718 @@
+//===========================================================================
+// TilerController's Internal FSM implementation
+//===========================================================================
+package gemmini
+
+import chisel3._
+import chisel3.util._
+import chisel3.experimental._
+import freechips.rocketchip.config._
+import freechips.rocketchip.tile._
+import GemminiISA._
+
+class TilerFSM[T <: Data : Arithmetic, U <: Data]
+  (config: GemminiArrayConfig[T,U])(implicit val p: Parameters) 
+  extends Module with HasCoreParameters {
+  import config._
+
+  //=========================================================================
+  // interface
+  //=========================================================================
+  val io = IO(new Bundle {
+    val cmd_in    = Flipped(Decoupled(new TilerCmd(LOG2_ROB_ENTRIES)))
+    val sched_out = Decoupled(new RoCCCommand)
+    val busy      = Output(Bool())
+  })
+  // hardcode 8 entries with up to 2 pushes per cycle
+  val schedq = Module(new MultiTailedQueue(new RoCCCommand, 8, 2))
+  io.sched_out <> schedq.io.deq
+
+  val sched = schedq.io.enq
+  val cmd   = io.cmd_in.bits
+  val busy  = io.busy
+
+  // initialize ports/pins
+  for (i <- 0 to 1) {
+    sched.bits(i) := DontCare
+    sched.bits(i).status := io.cmd_in.bits.status
+  }
+  sched.push := 0.U
+  io.cmd_in.ready := false.B
+  busy := true.B
+
+  //=========================================================================
+  // FSM states (see diagram for what each state does)
+  //=========================================================================
+  val (s_IDLE ::
+      s_RESET_OUTPUT_GROUP ::
+      s_RESET_A_TILE_SUBCOL ::
+      s_MOVE_FIRST_B_TILE_INTO_SP ::
+      s_RESET_B_TILE_SUBCOL_IN_SUBROW ::
+      s_MAYBE_MOVE_NEXT_B_TILE_INTO_SP ::
+      s_RESET_A_TILE_SUBROW_IN_SUBCOL ::
+      s_MAYBE_MOVE_A_TILE_INTO_SP ::
+      s_MAYBE_MOVE_D_TILE_INTO_ACC ::
+      s_PRELOAD_B_TILE_INTO_ARRAY_AND_SET_C_ADDR_IN_ACC ::
+      s_DO_MATMUL ::
+      s_MAYBE_MOVE_C_TILE_INTO_MEM ::
+      s_NEXT_A_TILE_SUBROW_IN_SUBCOL ::
+      s_NEXT_B_TILE_SUBCOL_IN_SUBROW ::
+      s_NEXT_A_TILE_SUBCOL ::
+      s_NEXT_OUTPUT_GROUP ::
+      Nil) = Enum(16)
+
+  val state = RegInit(s_IDLE)
+
+  //=========================================================================
+  // Internal State
+  //=========================================================================
+
+  // creates a Reg and the next-state Wire, and returns both
+  def regwire(bits: Int) = {
+    val wire = Wire(UInt(bits.W))
+    val reg = RegNext(wire)
+    wire := reg // default wire to read from reg
+    (reg, wire)
+  }
+
+  //------------------------------------------------------------------------
+  // input data-specific constants
+  //------------------------------------------------------------------------
+  val g_HAS_BIAS              = Reg(Bool())
+  val g_REPEATING_BIAS        = Reg(Bool())
+  // exec-configs
+  val g_DATAFLOW              = Reg(UInt(1.W))
+  val g_ACTIVATION            = Reg(UInt(2.W))
+  val g_SYSTOLIC_OUT_RSHIFT   = Reg(UInt(LOG2_OTYPE_BITS.W))
+  val g_ACC_OUT_RSHIFT        = Reg(UInt(LOG2_OTYPE_BITS.W))
+  val g_RELU6_IN_LSHIFT       = Reg(UInt(LOG2_OTYPE_BITS.W))
+  // mem-addr of A-matrix
+  val g_A_MEM_ADDR            = Reg(UInt(xLen.W))
+  val g_B_MEM_ADDR            = Reg(UInt(xLen.W))
+  val g_C_MEM_ADDR            = Reg(UInt(xLen.W))
+  val g_D_MEM_ADDR            = Reg(UInt(xLen.W))
+  // bytes in A-matrix row * rows-per-tile
+  val g_A_BYTES_PER_TILE_ROW  = Reg(UInt(LOG2_MNK_BYTES_PER_TILE_ROW.W))
+  val g_B_BYTES_PER_TILE_ROW  = Reg(UInt(LOG2_MNK_BYTES_PER_TILE_ROW.W))
+  val g_C_BYTES_PER_TILE_ROW  = Reg(UInt(LOG2_MNK_BYTES_PER_TILE_ROW.W))
+  val g_D_BYTES_PER_TILE_ROW  = Reg(UInt(LOG2_MNK_BYTES_PER_TILE_ROW.W))
+  // bytes in A-matrix row
+  val g_A_BYTES_PER_ROW       = Reg(UInt(LOG2_MNK_BYTES.W))
+  val g_B_BYTES_PER_ROW       = Reg(UInt(LOG2_MNK_BYTES.W))
+  val g_C_BYTES_PER_ROW       = Reg(UInt(LOG2_MNK_BYTES.W))
+  val g_D_BYTES_PER_ROW       = Reg(UInt(LOG2_MNK_BYTES.W))
+  // needed for 0-padding last rows/cols
+  val g_LAST_M_ITEMS          = Reg(UInt(LOG2_DIM_COUNT.W))
+  val g_LAST_N_ITEMS          = Reg(UInt(LOG2_DIM_COUNT.W))
+  val g_LAST_K_ITEMS          = Reg(UInt(LOG2_DIM_COUNT.W))
+  // last (x,y,x) tile idx in (C,C,A) matrix
+  val g_TILE_ROW_END          = Reg(UInt(LOG2_TILE_IDX.W))
+  val g_TILE_COL_END          = Reg(UInt(LOG2_TILE_IDX.W))
+  val g_K_TILE_COL_END        = Reg(UInt(LOG2_TILE_IDX.W))
+
+  //------------------------------------------------------------------------
+  // combinational calculation of optimal output-groups. this is updated at
+  // the s_IDLE -> s_RESET_OUTPUT_GROUP state transition
+  //------------------------------------------------------------------------
+  val g_OG_DIM_SELECT = OG_HEIGHT_MAP.zipWithIndex.map{ case(h,i) => 
+    val w = TOTAL_ACC_TILES/h
+    if (h < w)      WireDefault(g_TILE_ROW_END < h.U)
+    else if(h > w)  WireDefault(g_TILE_COL_END < w.U)
+    else            WireDefault((i == (OG_HEIGHT_MAP.size-1)).asBool)
+  }
+  val g_TILE_ROWS_PER_GROUP = MuxCase(
+    OG_HEIGHT_MAP(OG_HEIGHT_MAP.size-1).U,
+    OG_HEIGHT_MAP.zipWithIndex.map{
+      case(h,i) => (g_OG_DIM_SELECT(i) -> h.U)
+    })
+  val g_TILE_COLS_PER_GROUP = MuxCase(
+    (TOTAL_ACC_TILES / OG_HEIGHT_MAP(OG_HEIGHT_MAP.size-1)).U,
+    OG_HEIGHT_MAP.zipWithIndex.map{
+      case(h,i) => (g_OG_DIM_SELECT(i) -> (TOTAL_ACC_TILES/h).U)
+    })
+  val g_I_BYTE_COLS_PER_GROUP = g_TILE_COLS_PER_GROUP <<I_TILE_BYTE_WIDTH_LOG2
+  val g_O_BYTE_COLS_PER_GROUP = g_TILE_COLS_PER_GROUP <<O_TILE_BYTE_WIDTH_LOG2
+
+  //------------------------------------------------------------------------
+  // global state persistent across all loops
+  //------------------------------------------------------------------------
+  // current output-group tile (y,x)
+  val (gbl_tile_row, gbl_tile_row_n) = regwire(LOG2_TILE_IDX)
+  val (gbl_tile_col, gbl_tile_col_n) = regwire(LOG2_TILE_IDX)
+  // how many elements (tall,wide) is this tile
+  val gbl_item_rows = Reg(UInt(LOG2_DIM_COUNT.W))
+  val gbl_item_cols = Reg(UInt(LOG2_DIM_COUNT.W))
+  // which tmp-slot in sp being used now, and which is the alternate
+  val gbl_B_cur_sp_row_addr = Reg(UInt(LOG2_SP_ROWS.W))
+  val gbl_B_alt_sp_row_addr = Reg(UInt(LOG2_SP_ROWS.W))
+
+  //------------------------------------------------------------------------
+  // global state that is reset for each output-group
+  //------------------------------------------------------------------------
+  // where to put next C/D-tile in acc
+  val gbl_CD_acc_row_addr = Reg(UInt(LOG2_ACC_ROWS.W))
+
+  //------------------------------------------------------------------------
+  // loop1-local state
+  //------------------------------------------------------------------------
+  // (ul-x,ul-y,br-x,br-y) tile x in output-group
+  val loop1_tile_col_start = Reg(UInt(LOG2_TILE_IDX.W))
+  val loop1_tile_col_end   = Reg(UInt(LOG2_TILE_IDX.W))
+  val loop1_tile_row_start = Reg(UInt(LOG2_TILE_IDX.W))
+  val loop1_tile_row_end   = Reg(UInt(LOG2_TILE_IDX.W))
+  // initialized from global-constants
+  val loop1_A_mem_addr = Reg(UInt(xLen.W))
+  val loop1_B_mem_addr = Reg(UInt(xLen.W))
+  val loop1_C_mem_addr = Reg(UInt(xLen.W))
+  val loop1_D_mem_addr = Reg(UInt(xLen.W))
+
+  //------------------------------------------------------------------------
+  // loop2-local state
+  //------------------------------------------------------------------------
+  // which tile-column in A we are in
+  val (loop2_k_tile_col, loop2_k_tile_col_n) = regwire(LOG2_TILE_IDX)
+  // how many elems in k-dim is this tile
+  val loop2_k_item_dims = Reg(UInt(LOG2_DIM_COUNT.W))
+  // initialized from loop1 values
+  val loop2_A_mem_addr = Reg(UInt(xLen.W))
+  val loop2_B_mem_addr = Reg(UInt(xLen.W))
+  val loop2_C_mem_addr = Reg(UInt(xLen.W))
+  val loop2_D_mem_addr = Reg(UInt(xLen.W))
+
+  //------------------------------------------------------------------------
+  // loop3-local state
+  //------------------------------------------------------------------------
+  // initialized from loop2 values
+  val loop3_A_mem_addr = Reg(UInt(xLen.W))
+  val loop3_B_mem_addr = Reg(UInt(xLen.W))
+  val loop3_C_mem_addr = Reg(UInt(xLen.W))
+  val loop3_D_mem_addr = Reg(UInt(xLen.W))
+
+  //------------------------------------------------------------------------
+  // loop4-local state
+  //------------------------------------------------------------------------
+  // where in the sp is the next A tile
+  val loop4_A_sp_row_addr = Reg(UInt(LOG2_SP_ROWS.W))
+  // initialized from loop3 values
+  val loop4_A_mem_addr = Reg(UInt(xLen.W))
+  val loop4_B_mem_addr = Reg(UInt(xLen.W))
+  val loop4_C_mem_addr = Reg(UInt(xLen.W))
+  val loop4_D_mem_addr = Reg(UInt(xLen.W))
+
+  //=========================================================================
+  // utilies used by FSM core
+  //=========================================================================
+
+  // continuous assigns (only added in the switch-cases that call this!)
+  def update_tile_dims(dummy: Int = 0) = {
+    gbl_item_rows     := Mux(gbl_tile_row_n === g_TILE_ROW_END, 
+                             g_LAST_M_ITEMS, DIM.U)
+    gbl_item_cols     := Mux(gbl_tile_col_n === g_TILE_COL_END, 
+                             g_LAST_N_ITEMS, DIM.U)
+    loop2_k_item_dims := Mux(loop2_k_tile_col_n === g_K_TILE_COL_END,
+                             g_LAST_K_ITEMS, DIM.U)
+  }
+
+  def MIN(a: UInt, b: UInt) = Mux(a < b, a, b)
+
+  //=========================================================================
+  // FSM core
+  //=========================================================================
+  switch (state) {
+    is (s_IDLE) {
+      val l_HAS_BIAS      = (cmd.addr_d =/= 0.U)
+      val l_A_BYTE_WIDTH  = WireDefault(cmd.k << LOG2_ITYPE_BYTES.U)
+      val l_BC_BYTE_WIDTH = WireDefault(cmd.n << LOG2_ITYPE_BYTES.U)
+      val l_D_BYTE_WIDTH  = WireDefault(cmd.n << LOG2_OTYPE_BYTES.U)
+
+      g_HAS_BIAS              := l_HAS_BIAS
+      g_REPEATING_BIAS        := cmd.repeating_bias
+
+      g_DATAFLOW              := Dataflow.WS.id.U
+      g_ACTIVATION            := cmd.activation
+      g_SYSTOLIC_OUT_RSHIFT   := cmd.in_rshift
+      g_ACC_OUT_RSHIFT        := cmd.acc_rshift
+      g_RELU6_IN_LSHIFT       := cmd.relu6_lshift
+
+      g_A_MEM_ADDR            := cmd.addr_a
+      g_B_MEM_ADDR            := cmd.addr_b
+      g_C_MEM_ADDR            := cmd.addr_c
+      g_D_MEM_ADDR            := cmd.addr_d
+
+      g_A_BYTES_PER_TILE_ROW  := l_A_BYTE_WIDTH  << LOG2_DIM.U
+      g_B_BYTES_PER_TILE_ROW  := l_BC_BYTE_WIDTH << LOG2_DIM.U
+      g_C_BYTES_PER_TILE_ROW  := l_BC_BYTE_WIDTH << LOG2_DIM.U
+      g_D_BYTES_PER_TILE_ROW  := l_D_BYTE_WIDTH  << LOG2_DIM.U
+
+      g_A_BYTES_PER_ROW       := l_A_BYTE_WIDTH
+      g_B_BYTES_PER_ROW       := l_BC_BYTE_WIDTH
+      g_C_BYTES_PER_ROW       := l_BC_BYTE_WIDTH
+      g_D_BYTES_PER_ROW       := l_D_BYTE_WIDTH
+
+      g_LAST_M_ITEMS := Mux(cmd.m(LOG2_DIM-1,0).orR,cmd.m(LOG2_DIM-1,0),DIM.U)
+      g_LAST_N_ITEMS := Mux(cmd.n(LOG2_DIM-1,0).orR,cmd.n(LOG2_DIM-1,0),DIM.U)
+      g_LAST_K_ITEMS := Mux(cmd.k(LOG2_DIM-1,0).orR,cmd.k(LOG2_DIM-1,0),DIM.U)
+
+      g_TILE_ROW_END   := (cmd.m >> LOG2_DIM) + cmd.m(LOG2_DIM-1,0).orR - 1.U 
+      g_TILE_COL_END   := (cmd.n >> LOG2_DIM) + cmd.n(LOG2_DIM-1,0).orR - 1.U
+      g_K_TILE_COL_END := (cmd.k >> LOG2_DIM) + cmd.k(LOG2_DIM-1,0).orR - 1.U
+
+      // update interface signals. we are only ready when an input cmd is
+      // ready AND the output queue has 2 slots available to write to
+      io.cmd_in.ready := (sched.ready >= 2.U)
+
+      // issue gemmini commands
+      // NOTE: the "h10000".U(17) is because a_addr_stride was added to ExecuteController
+      when(io.cmd_in.fire()) {
+        sched.push               := 2.U
+        sched.bits(0).inst.funct := CONFIG_CMD
+        sched.bits(0).rs1        := (g_ACC_OUT_RSHIFT << 32) |
+                                    "h10000".U(17.W) |
+                                    (g_ACTIVATION << 3) |
+                                    (g_DATAFLOW << 2) |
+                                    CONFIG_EX
+        sched.bits(0).rs2        := (g_RELU6_IN_LSHIFT << 32) |
+                                    g_SYSTOLIC_OUT_RSHIFT
+        sched.bits(1).inst.funct := CONFIG_CMD
+        sched.bits(1).rs1        := CONFIG_STORE
+        sched.bits(1).rs2        := g_C_BYTES_PER_ROW
+
+        // update next state
+        state := s_RESET_OUTPUT_GROUP
+      }
+      .otherwise {
+        // if we are sitting in idle state, we are not busy!
+        busy := false.B
+      }
+    }
+    //=======================================================================
+    is (s_RESET_OUTPUT_GROUP) {
+      // define mutable gbl state, persist across all ogs
+      gbl_tile_row_n        := 0.U
+      gbl_tile_col_n        := 0.U
+      gbl_B_cur_sp_row_addr := GBL_B_SP_ROW_ADDR_1.U
+      gbl_B_alt_sp_row_addr := GBL_B_SP_ROW_ADDR_2.U
+      update_tile_dims()
+
+      // define mutable gbl state, reset after each og
+      gbl_CD_acc_row_addr := 0.U
+
+      loop1_tile_col_start := gbl_tile_col_n
+      loop1_tile_col_end   := MIN(gbl_tile_col_n + g_TILE_COLS_PER_GROUP-1.U,
+                                  g_TILE_COL_END)
+      loop1_tile_row_start := gbl_tile_row_n
+      loop1_tile_row_end   := MIN(gbl_tile_row_n + g_TILE_ROWS_PER_GROUP-1.U,
+                                  g_TILE_ROW_END)
+
+      // derived pointers to matrices in memory for this og
+      loop1_A_mem_addr := g_A_MEM_ADDR
+      loop1_B_mem_addr := g_B_MEM_ADDR
+      loop1_C_mem_addr := g_C_MEM_ADDR
+      loop1_D_mem_addr := g_D_MEM_ADDR
+
+      // update next state
+      state := s_RESET_A_TILE_SUBCOL
+    }
+    //=======================================================================
+    is (s_RESET_A_TILE_SUBCOL) {
+      loop2_k_tile_col_n  := 0.U
+      gbl_tile_row_n      := loop1_tile_row_start
+      gbl_tile_col_n      := loop1_tile_col_start
+      gbl_CD_acc_row_addr := 0.U
+      update_tile_dims()
+
+      loop2_A_mem_addr := loop1_A_mem_addr
+      loop2_B_mem_addr := loop1_B_mem_addr
+      loop2_C_mem_addr := loop1_C_mem_addr
+      loop2_D_mem_addr := loop1_D_mem_addr
+
+      // update next state
+      state := s_MOVE_FIRST_B_TILE_INTO_SP
+    }
+    //=======================================================================
+    is (s_MOVE_FIRST_B_TILE_INTO_SP) {
+      // calculate mvin parameters
+      val B_mem_addr    = loop2_B_mem_addr
+      val B_mem_stride  = g_B_BYTES_PER_ROW
+
+      val B_sp_row_addr = Wire(UInt(32.W))
+      val B_item_rows   = Wire(UInt(16.W))
+      val B_item_cols   = Wire(UInt(16.W))
+      B_sp_row_addr := gbl_B_cur_sp_row_addr
+      B_item_rows   := loop2_k_item_dims
+      B_item_cols   := gbl_item_cols
+
+      // issue gemmini commands
+      when(sched.ready >= 2.U) {
+        sched.push          := 2.U
+        // NOTE: set 33rd bit to 1 so LoadController scaling works
+        sched.bits(0).rs1   := "h100000000".U(33.W) | CONFIG_LOAD
+        sched.bits(0).rs2   := B_mem_stride
+        sched.bits(0).inst.funct := CONFIG_CMD
+        sched.bits(1).rs1   := B_mem_addr
+        sched.bits(1).rs2   := Cat(B_item_rows,B_item_cols,B_sp_row_addr)
+        sched.bits(1).inst.funct := LOAD_CMD
+
+        // update next state
+        state := s_RESET_B_TILE_SUBCOL_IN_SUBROW
+      }
+    }
+    //=======================================================================
+    is (s_RESET_B_TILE_SUBCOL_IN_SUBROW) {
+      loop3_A_mem_addr := loop2_A_mem_addr
+      loop3_B_mem_addr := loop2_B_mem_addr
+      loop3_C_mem_addr := loop2_C_mem_addr
+      loop3_D_mem_addr := loop2_D_mem_addr
+
+      // update next state
+      state := s_MAYBE_MOVE_NEXT_B_TILE_INTO_SP
+    }
+    //=======================================================================
+    is (s_MAYBE_MOVE_NEXT_B_TILE_INTO_SP) {
+      // calculate mvin parameters
+      val B_mem_addr    = loop3_B_mem_addr + I_TILE_BYTE_WIDTH.U
+      val B_mem_stride  = g_B_BYTES_PER_ROW
+
+      val B_sp_row_addr = Wire(UInt(32.W))
+      val B_item_rows   = Wire(UInt(16.W))
+      val B_item_cols   = Wire(UInt(16.W))
+      B_sp_row_addr := gbl_B_alt_sp_row_addr
+      B_item_rows   := loop2_k_item_dims
+      B_item_cols   := Mux(gbl_tile_col === g_TILE_COL_END-1.U,
+                           g_LAST_N_ITEMS, DIM.U)
+
+      // can't load next B-tile if we are already on the last one
+      when (gbl_tile_col === loop1_tile_col_end) {
+        state := s_RESET_A_TILE_SUBROW_IN_SUBCOL
+      }
+      .elsewhen (sched.ready >= 2.U) {
+        sched.push          := 2.U
+        sched.bits(0).rs1   := "h100000000".U(33.W) | CONFIG_LOAD
+        sched.bits(0).rs2   := B_mem_stride
+        sched.bits(0).inst.funct := CONFIG_CMD
+        sched.bits(1).rs1   := B_mem_addr
+        sched.bits(1).rs2   := Cat(B_item_rows,B_item_cols,B_sp_row_addr)
+        sched.bits(1).inst.funct := LOAD_CMD
+
+        // update next state
+        state := s_RESET_A_TILE_SUBROW_IN_SUBCOL
+      }
+    }
+    //=======================================================================
+    is (s_RESET_A_TILE_SUBROW_IN_SUBCOL) {
+      // this scope modifies: gbl_tile_row
+      //                      gbl_CD_acc_row_addr
+      loop4_A_mem_addr := loop3_A_mem_addr
+      loop4_B_mem_addr := loop3_B_mem_addr
+      loop4_C_mem_addr := loop3_C_mem_addr
+      loop4_D_mem_addr := loop3_D_mem_addr
+
+      loop4_A_sp_row_addr := 0.U
+
+      // update next state
+      state := s_MAYBE_MOVE_A_TILE_INTO_SP
+    }
+    //=======================================================================
+    is (s_MAYBE_MOVE_A_TILE_INTO_SP) {
+      // calculate mvin parameters
+      val A_mem_addr    = loop4_A_mem_addr
+      val A_mem_stride  = g_A_BYTES_PER_ROW
+
+      val A_sp_row_addr = Wire(UInt(32.W))
+      val A_item_rows   = Wire(UInt(16.W))
+      val A_item_cols   = Wire(UInt(16.W))
+      A_sp_row_addr := loop4_A_sp_row_addr
+      A_item_rows   := gbl_item_rows
+      A_item_cols   := loop2_k_item_dims
+
+      // only move A-tiles in during first column of tiles in the og
+      when (gbl_tile_col =/= loop1_tile_col_start) {
+        state := s_MAYBE_MOVE_D_TILE_INTO_ACC
+      }
+      .elsewhen (sched.ready >= 2.U) {
+        sched.push          := 2.U
+        sched.bits(0).rs1   := "h100000000".U(33.W) | CONFIG_LOAD
+        sched.bits(0).rs2   := A_mem_stride
+        sched.bits(0).inst.funct := CONFIG_CMD
+        sched.bits(1).rs1   := A_mem_addr
+        sched.bits(1).rs2   := Cat(A_item_rows,A_item_cols,A_sp_row_addr)
+        sched.bits(1).inst.funct := LOAD_CMD
+
+        // update next state
+        state := s_MAYBE_MOVE_D_TILE_INTO_ACC
+      }
+    }
+    //=======================================================================
+    is (s_MAYBE_MOVE_D_TILE_INTO_ACC) {
+      // calculate mvin parameters (NOTE: we know D is valid at this point)
+      val D_mem_addr     = loop4_D_mem_addr
+      val D_mem_stride   = Mux(g_REPEATING_BIAS, 0.U, g_D_BYTES_PER_ROW)
+
+      val D_acc_row_addr = Wire(UInt(32.W))
+      val D_item_rows    = Wire(UInt(16.W))
+      val D_item_cols    = Wire(UInt(16.W))
+      D_acc_row_addr := "h80000000".U | gbl_CD_acc_row_addr
+      D_item_rows    := gbl_item_rows
+      D_item_cols    := gbl_item_cols
+
+      // only move D-tiles in during first partial-sum in an output-group
+      when((loop2_k_tile_col =/= 0.U) || !g_HAS_BIAS) {
+        state := s_PRELOAD_B_TILE_INTO_ARRAY_AND_SET_C_ADDR_IN_ACC
+      }
+      .elsewhen (sched.ready >= 2.U) {
+        sched.push          := 2.U
+        sched.bits(0).rs1   := "h100000000".U(33.W) | CONFIG_LOAD
+        sched.bits(0).rs2   := D_mem_stride
+        sched.bits(0).inst.funct := CONFIG_CMD
+        sched.bits(1).rs1   := D_mem_addr
+        sched.bits(1).rs2   := Cat(D_item_rows,D_item_cols,D_acc_row_addr)
+        sched.bits(1).inst.funct := LOAD_CMD
+
+        // update next state
+        state := s_PRELOAD_B_TILE_INTO_ARRAY_AND_SET_C_ADDR_IN_ACC
+      }
+    }
+    //=======================================================================
+    is (s_PRELOAD_B_TILE_INTO_ARRAY_AND_SET_C_ADDR_IN_ACC) {
+      // on first tile in 4th loop: preload this B-tile
+      // else:                      preload garbage B-tile (no spad load)
+      val B_sp_row_addr = Wire(UInt(32.W))
+      val B_item_rows   = Wire(UInt(16.W))
+      val B_item_cols   = Wire(UInt(16.W))
+      B_sp_row_addr := Mux(gbl_tile_row === loop1_tile_row_start,
+                           gbl_B_cur_sp_row_addr,
+                           GARBAGE_ADDR)
+      B_item_rows   := loop2_k_item_dims
+      B_item_cols   := gbl_item_cols
+
+      // if has D-bias already loaded: accumulate c in accumulator
+      // elif first k-col in 2nd loop: overwrite c in accumulator
+      // else:                         accumulate c in accumulator
+      val C_acc_row_addr = Wire(UInt(32.W))
+      val C_item_rows    = Wire(UInt(16.W))
+      val C_item_cols    = Wire(UInt(16.W))
+      C_acc_row_addr := Mux(g_HAS_BIAS || (loop2_k_tile_col > 0.U),
+                            "hC0000000".U | gbl_CD_acc_row_addr,
+                            "h80000000".U | gbl_CD_acc_row_addr)
+      C_item_rows    := gbl_item_rows
+      C_item_cols    := gbl_item_cols
+
+      when (sched.ready >= 1.U) {
+        sched.push          := 1.U
+        sched.bits(0).rs1   := Cat(B_item_rows,B_item_cols,B_sp_row_addr)
+        sched.bits(0).rs2   := Cat(C_item_rows,C_item_cols,C_acc_row_addr)
+        sched.bits(0).inst.funct := PRELOAD_CMD
+
+        // update next state
+        state := s_DO_MATMUL
+      }
+    }
+    //=======================================================================
+    is (s_DO_MATMUL) {
+      // calculate compute parameters
+      val A_sp_row_addr = Wire(UInt(32.W))
+      val A_item_rows   = Wire(UInt(16.W))
+      val A_item_cols   = Wire(UInt(16.W))
+      A_sp_row_addr := loop4_A_sp_row_addr
+      A_item_rows   := gbl_item_rows
+      A_item_cols   := loop2_k_item_dims
+
+      val D_acc_row_addr = GARBAGE_ADDR
+      val D_item_rows    = Wire(UInt(16.W))
+      val D_item_cols    = Wire(UInt(16.W))
+      D_item_rows    := gbl_item_rows
+      D_item_cols    := gbl_item_cols
+
+      // on first tile in 4th loop: compute_preloaded
+      // else: compute_accumulated
+      when (sched.ready >= 1.U) {
+        sched.push          := 1.U
+        sched.bits(0).rs1   := Cat(A_item_rows,A_item_cols,A_sp_row_addr)
+        sched.bits(0).rs2   := Cat(D_item_rows,D_item_cols,D_acc_row_addr)
+        when (gbl_tile_row === loop1_tile_row_start) {
+          sched.bits(0).inst.funct := COMPUTE_AND_FLIP_CMD
+        }
+        .otherwise {
+          sched.bits(0).inst.funct := COMPUTE_AND_STAY_CMD
+        }
+        // update next state
+        state := s_MAYBE_MOVE_C_TILE_INTO_MEM
+      }
+    }
+    //=======================================================================
+    is (s_MAYBE_MOVE_C_TILE_INTO_MEM) {
+      val C_mem_addr     = loop4_C_mem_addr
+      val C_mem_stride   = g_C_BYTES_PER_ROW
+
+      val C_acc_row_addr = Wire(UInt(32.W))
+      val C_item_rows    = Wire(UInt(16.W))
+      val C_item_cols    = Wire(UInt(16.W))
+      C_acc_row_addr := "h80000000".U | gbl_CD_acc_row_addr
+      C_item_rows    := gbl_item_rows
+      C_item_cols    := gbl_item_cols
+
+      when(loop2_k_tile_col =/= g_K_TILE_COL_END) {
+        state := s_NEXT_A_TILE_SUBROW_IN_SUBCOL
+      }
+      .elsewhen (sched.ready >= 1.U) {
+        sched.push          := 1.U
+        sched.bits(0).rs1   := C_mem_addr
+        sched.bits(0).rs2   := Cat(C_item_rows,C_item_cols,C_acc_row_addr)
+        sched.bits(0).inst.funct := STORE_CMD
+
+        // update next state
+        state := s_NEXT_A_TILE_SUBROW_IN_SUBCOL
+      }
+    }
+    //=======================================================================
+    is (s_NEXT_A_TILE_SUBROW_IN_SUBCOL) {
+      when (gbl_tile_row === loop1_tile_row_end) {
+        // just finished the final row of tiles in the 4th loop
+        state := s_NEXT_B_TILE_SUBCOL_IN_SUBROW
+      }
+      .otherwise {
+        // modify global state
+        gbl_tile_row_n      := gbl_tile_row        + 1.U
+        gbl_CD_acc_row_addr := gbl_CD_acc_row_addr + BYTE_ROWS_PER_TILE.U
+        update_tile_dims()
+
+        // modify loop4-local state
+        loop4_A_mem_addr    := loop4_A_mem_addr + g_A_BYTES_PER_TILE_ROW
+        loop4_B_mem_addr    := loop4_B_mem_addr
+        loop4_C_mem_addr    := loop4_C_mem_addr + g_C_BYTES_PER_TILE_ROW
+        loop4_D_mem_addr    := loop4_D_mem_addr +
+                                Mux(g_HAS_BIAS && !g_REPEATING_BIAS,
+                                    g_D_BYTES_PER_TILE_ROW, 0.U)
+
+        loop4_A_sp_row_addr := loop4_A_sp_row_addr + BYTE_ROWS_PER_TILE.U
+
+        // update next state
+        state := s_MAYBE_MOVE_A_TILE_INTO_SP
+      }
+    }
+    //=======================================================================
+    is (s_NEXT_B_TILE_SUBCOL_IN_SUBROW) {
+      when (gbl_tile_col === loop1_tile_col_end) {
+        // we have already done the last column in the output-group
+        state := s_NEXT_A_TILE_SUBCOL
+      }
+      .otherwise {
+        // modify global state
+        gbl_tile_row_n      := loop1_tile_row_start
+        gbl_tile_col_n      := gbl_tile_col        + 1.U
+        gbl_CD_acc_row_addr := gbl_CD_acc_row_addr + BYTE_ROWS_PER_TILE.U
+        update_tile_dims()
+
+        gbl_B_cur_sp_row_addr := gbl_B_alt_sp_row_addr
+        gbl_B_alt_sp_row_addr := gbl_B_cur_sp_row_addr
+
+        // modify loop3-local state
+        loop3_A_mem_addr := loop3_A_mem_addr + 0.U
+        loop3_B_mem_addr := loop3_B_mem_addr + I_TILE_BYTE_WIDTH.U
+        loop3_C_mem_addr := loop3_C_mem_addr + I_TILE_BYTE_WIDTH.U
+        loop3_D_mem_addr := loop3_D_mem_addr + O_TILE_BYTE_WIDTH.U
+
+        // update next state
+        state := s_MAYBE_MOVE_NEXT_B_TILE_INTO_SP
+      }
+    }
+    //=======================================================================
+    is (s_NEXT_A_TILE_SUBCOL) {
+      when (loop2_k_tile_col === g_K_TILE_COL_END) {
+        state := s_NEXT_OUTPUT_GROUP
+      }
+      .otherwise {
+        loop2_k_tile_col_n  := loop2_k_tile_col + 1.U
+        gbl_tile_row_n      := loop1_tile_row_start
+        gbl_tile_col_n      := loop1_tile_col_start
+        gbl_CD_acc_row_addr := 0.U
+        update_tile_dims()
+
+        loop2_A_mem_addr := loop2_A_mem_addr + I_TILE_BYTE_WIDTH.U
+        loop2_B_mem_addr := loop2_B_mem_addr + g_B_BYTES_PER_TILE_ROW
+        loop2_C_mem_addr := loop2_C_mem_addr + 0.U
+        loop2_D_mem_addr := loop2_D_mem_addr + 0.U
+
+        // swap current/alternate B-tile scratchpad addrs
+        gbl_B_cur_sp_row_addr := gbl_B_alt_sp_row_addr
+        gbl_B_alt_sp_row_addr := gbl_B_cur_sp_row_addr
+
+        // update next state
+        state := s_MOVE_FIRST_B_TILE_INTO_SP
+      }
+    }
+    //=======================================================================
+    is (s_NEXT_OUTPUT_GROUP) {
+      val l_did_row_incr = WireDefault(false.B)
+      val l_did_col_incr = WireDefault(false.B)
+
+      when (gbl_tile_col === g_TILE_COL_END && 
+            gbl_tile_row === g_TILE_ROW_END) {
+        // update next state
+        state := s_IDLE
+      }
+      .otherwise {
+        when (gbl_tile_col === g_TILE_COL_END) {
+          gbl_tile_row_n := gbl_tile_row + 1.U
+          gbl_tile_col_n := 0.U
+          update_tile_dims()
+          l_did_row_incr := true.B
+        }
+        .otherwise {
+          // TODO: this is a bug!
+          gbl_tile_row_n := gbl_tile_row
+          gbl_tile_col_n := gbl_tile_col + 1.U
+          update_tile_dims()
+          l_did_col_incr := true.B
+        }
+   
+        // reset global state that resets for each new output-group
+        gbl_CD_acc_row_addr := 0.U
+
+        // update the start/end tiles for this output-group (inclusive)
+        val l_tile_col_start = gbl_tile_col_n
+        val l_tile_col_end  = MIN(gbl_tile_col_n + g_TILE_COLS_PER_GROUP-1.U,
+                                  g_TILE_COL_END)
+        val l_tile_row_start = gbl_tile_row_n
+        val l_tile_row_end  = MIN(gbl_tile_row_n + g_TILE_ROWS_PER_GROUP-1.U,
+                                  g_TILE_ROW_END)
+
+        loop1_tile_col_start := l_tile_col_start
+        loop1_tile_col_end   := l_tile_col_end
+                                
+        loop1_tile_row_start := l_tile_row_start
+        loop1_tile_row_end   := l_tile_row_end
+                                
+         
+        // update all derived pointers to matrices in memory
+        when(l_did_row_incr) {
+          loop1_A_mem_addr := g_A_MEM_ADDR + (l_tile_row_start *
+                                              g_A_BYTES_PER_TILE_ROW)
+          loop1_B_mem_addr := g_B_MEM_ADDR
+          loop1_C_mem_addr := g_C_MEM_ADDR + (l_tile_row_start *
+                                              g_C_BYTES_PER_TILE_ROW)
+          loop1_D_mem_addr := Mux(!g_HAS_BIAS, 0.U,
+                                Mux(g_REPEATING_BIAS, g_D_MEM_ADDR,
+                                 (g_D_MEM_ADDR + (l_tile_row_start *
+                                                  g_D_BYTES_PER_TILE_ROW))))
+        }
+        .elsewhen (l_did_col_incr) {
+          loop1_A_mem_addr := loop1_A_mem_addr + 0.U
+          loop1_B_mem_addr := loop1_B_mem_addr + g_I_BYTE_COLS_PER_GROUP
+          loop1_C_mem_addr := loop1_C_mem_addr + g_I_BYTE_COLS_PER_GROUP
+          loop1_D_mem_addr := loop1_D_mem_addr + 
+                              Mux(!g_HAS_BIAS, 0.U, g_O_BYTE_COLS_PER_GROUP)
+        }
+
+        // update next state
+        state := s_RESET_A_TILE_SUBCOL
+      }
+    }
+  }
+}
+
+object TilerFSM {
+  def apply[T <: Data: Arithmetic, U <: Data]
+    (config: GemminiArrayConfig[T,U])(implicit p: Parameters)
+      = Module(new TilerFSM(config))
+}

--- a/src/main/scala/gemmini/TilerScheduler.scala
+++ b/src/main/scala/gemmini/TilerScheduler.scala
@@ -1,0 +1,452 @@
+//===========================================================================
+// TilerController's Internal Scheduler implementation
+//===========================================================================
+package gemmini
+
+import chisel3._
+import chisel3.util._
+import freechips.rocketchip.config._
+import freechips.rocketchip.tile._
+import GemminiISA._
+import Util._
+
+class TilerScheduler[T <: Data: Arithmetic, U <: Data]
+  (config: GemminiArrayConfig[T,U])(implicit val p: Parameters) 
+  extends Module with HasCoreParameters {
+  import config._
+
+  //=========================================================================
+  // interface
+  //=========================================================================
+  val io = IO(new Bundle {
+    val cmd_in = Flipped(Decoupled(new RoCCCommand))
+    val issue = new Bundle {
+      val exec  = Decoupled(new GemminiCmd(ROB_ENTRIES))
+      val load  = Decoupled(new GemminiCmd(ROB_ENTRIES))
+      val store = Decoupled(new GemminiCmd(ROB_ENTRIES))
+    }
+    val completed = Flipped(Decoupled(UInt(LOG2_ROB_ENTRIES.W)))
+    val busy = Output(Bool())
+  })
+  io.completed.ready := true.B
+
+  //=========================================================================
+  // ...
+  //=========================================================================
+  val ldq :: stq :: exq :: Nil = Enum(3)
+  val q_t = ldq.cloneType
+
+  val MAX_CMD_ID   = 1000000            // FOR DEBUGGING ONLY
+  val debug_cycle  = RegInit(0.U(32.W)) // FOR DEBUGGING ONLY
+
+  debug_cycle := debug_cycle + 1.U      // FOR DEBUGGING ONLY
+  val cmd_id = Counter(MAX_CMD_ID)      // FOR DEBUGGING ONLY
+
+  // scratchpad range, used for tracking RAW, WAR, and WAW deps
+  class SPRange extends Bundle {
+    val valid  = Bool()
+    val is_acc = Bool()
+    val start  = UInt(30.W) // TODO magic number
+    val end    = UInt(30.W) // TODO magic number
+    def overlaps(other: SPRange) = valid && other.valid && 
+                                   (is_acc === other.is_acc) &&
+                                   (start < other.end) && 
+                                   (end > other.start)
+  }
+
+  class Entry extends Bundle {
+    val q = q_t.cloneType
+
+    val is_config = Bool()
+
+    val cmd_id     = UInt(log2Up(MAX_CMD_ID).W)   // FOR DEBUGGING ONLY
+    val is_load    = Bool()  // also true on config_load.  FOR DEBUGGING ONLY
+    val is_store   = Bool()  // also true on config_store. FOR DEBUGGING ONLY
+    val is_exec    = Bool()  // also true on config_ex.    FOR DEBUGGING ONLY
+    val is_preload = Bool()  // FOR DEBUGGING ONLY
+
+    val op1 = new SPRange()
+    val op2 = new SPRange()
+    val dst = new SPRange()
+
+    val issued = Bool()
+
+    val complete_on_issue = Bool()
+
+    val cmd = new RoCCCommand
+
+    val deps = Vec(ROB_ENTRIES, Bool())
+    def ready(dummy: Int = 0): Bool = !deps.reduce(_ || _)
+  }
+
+  val entries = Reg(Vec(ROB_ENTRIES, UDValid(new Entry)))
+
+  val empty = !entries.map(_.valid).reduce(_ || _)
+  val full = entries.map(_.valid).reduce(_ && _)
+
+  io.busy := !empty
+
+  // Read in commands to the buffer
+  io.cmd_in.ready := !full
+
+  val last_allocated = Reg(UInt(log2Up(ROB_ENTRIES).W))
+
+  val new_entry = Wire(new Entry)
+  new_entry := DontCare
+  val new_entry_id = MuxCase((ROB_ENTRIES-1).U, entries.zipWithIndex.map { 
+                                        case (e, i) => !e.valid -> i.U })
+  val alloc_fire = io.cmd_in.fire()
+
+  when (io.cmd_in.fire()) {
+    val cmd = io.cmd_in.bits
+    val funct = cmd.inst.funct
+    val funct_is_compute = funct === COMPUTE_AND_STAY_CMD || 
+                           funct === COMPUTE_AND_FLIP_CMD
+    val funct_is_compute_preload = funct === COMPUTE_AND_FLIP_CMD
+    val config_cmd_type = cmd.rs1(1,0) // TODO magic numbers
+
+    new_entry.issued := false.B
+    new_entry.cmd := cmd
+
+    new_entry.is_config := funct === CONFIG_CMD
+
+    new_entry.op1.valid  := funct === PRELOAD_CMD || funct_is_compute
+    new_entry.op1.is_acc := cmd.rs1(31)
+    new_entry.op1.start  := cmd.rs1(29,0)
+    new_entry.op1.end    := cmd.rs1(29,0) + DIM.U
+
+    val mvin_mvout_rows = cmd.rs2(63, 48)
+    val mvin_mvout_cols = cmd.rs2(47, 32)
+
+    new_entry.op2.valid := funct_is_compute || funct === STORE_CMD
+    new_entry.op2.is_acc := cmd.rs2(31)
+    new_entry.op2.start := cmd.rs2(29,0)
+    new_entry.op2.end   := cmd.rs2(29,0) + 
+                           Mux(funct_is_compute, DIM.U, mvin_mvout_rows)
+
+    new_entry.dst.valid := funct === PRELOAD_CMD || funct === LOAD_CMD
+    new_entry.dst.is_acc := cmd.rs2(31)
+    new_entry.dst.start := cmd.rs2(29,0)
+    new_entry.dst.end   := cmd.rs2(29,0) + 
+                           Mux(funct === PRELOAD_CMD, DIM.U, 
+                            mvin_mvout_rows)
+
+    val is_load    = (funct === LOAD_CMD) || 
+                     (funct === CONFIG_CMD && config_cmd_type === CONFIG_LOAD)
+    val is_store   = (funct === STORE_CMD) || 
+                     (funct === CONFIG_CMD && config_cmd_type === CONFIG_STORE)
+    val is_exec    = funct === PRELOAD_CMD ||
+                     funct_is_compute || 
+                     (funct === CONFIG_CMD && config_cmd_type === CONFIG_EX)
+    val is_preload = funct === PRELOAD_CMD
+
+    // never allow this to wrap.FOR DEBUGGING ONLY
+    assert(!cmd_id.inc())
+    new_entry.cmd_id     := cmd_id.value // FOR DEBUGGING ONLY
+    new_entry.is_load    := is_load      // FOR DEBUGGING ONLY
+    new_entry.is_store   := is_store     // FOR DEBUGGING ONLY
+    new_entry.is_exec    := is_exec      // FOR DEBUGGING ONLY
+    new_entry.is_preload := is_preload   // FOR DEBUGGING ONLY
+    //======================================================================
+    // debug
+    //======================================================================
+    when(new_entry.is_config) {
+      when (new_entry.is_load) {
+        printf(
+          "cycle[%d], entry[%d], accept[%d], config_mvin[stride=%x]\n", 
+          debug_cycle, new_entry_id, cmd_id.value, 
+          new_entry.cmd.rs2)
+      }
+      .elsewhen (new_entry.is_store) {
+        printf(
+          "cycle[%d], entry[%d], accept[%d], config_mvout[stride=%x]\n", 
+          debug_cycle, new_entry_id, cmd_id.value, 
+          new_entry.cmd.rs2)
+      }
+      .otherwise {
+        assert(new_entry.is_exec)
+        printf(
+          "cycle[%d], entry[%d], accept[%d], " +
+          "config_ex[matmul_rshift=%x, acc_rshift=%x, relu6_lshift=%x]\n", 
+          debug_cycle, new_entry_id, cmd_id.value, 
+          cmd.rs1(63,32), cmd.rs2(31,0), cmd.rs2(63,32))
+      }
+    }
+    .elsewhen (new_entry.is_load) {
+      printf(
+        "cycle[%d], entry[%d], accept[%d], " +
+        "mvin[dram=%x, spad=%x, rows=%x, cols=%x]\n",
+        debug_cycle, new_entry_id, cmd_id.value, 
+        cmd.rs1, cmd.rs2(31,0), cmd.rs2(63,48), cmd.rs2(47,32))
+    }
+    .elsewhen (new_entry.is_store) {
+      printf(
+        "cycle[%d], entry[%d], accept[%d], " + 
+        "mvout[dram=%x, spad=%x, rows=%x, cols=%x]\n",
+        debug_cycle, new_entry_id, cmd_id.value, 
+        cmd.rs1, cmd.rs2(31,0), cmd.rs2(63,48), cmd.rs2(47,32))
+    }
+    .elsewhen (new_entry.is_preload) {
+      printf(
+        "cycle[%d], entry[%d], accept[%d], preload[B=%x, C=%x]\n",
+        debug_cycle, new_entry_id, cmd_id.value, 
+        cmd.rs1(31,0), cmd.rs2(31,0))
+    }
+    .otherwise {
+      assert(new_entry.is_exec)
+      when (funct_is_compute_preload) {
+        printf(
+          "cycle[%d], entry[%d], accept[%d], ex.pre[A=%x, D=%x]\n",
+          debug_cycle, new_entry_id, cmd_id.value, 
+          cmd.rs1(31,0), cmd.rs2(31,0))
+      }
+      .otherwise {
+        printf(
+          "cycle[%d], entry[%d], accept[%d], ex.acc[A=%x, D=%x]\n",
+          debug_cycle, new_entry_id, cmd_id.value, 
+          cmd.rs1(31,0), cmd.rs2(31,0))
+      }
+    }
+
+    //======================================================================
+    new_entry.q := Mux1H(Seq(
+      is_load  -> ldq,
+      is_store -> stq,
+      is_exec  -> exq,
+    ))
+
+    // We search for all entries which write to an address which we read from
+    val raws = entries.map { e => e.valid && (
+      e.bits.dst.overlaps(new_entry.op1) ||
+      e.bits.dst.overlaps(new_entry.op2)
+    )}
+
+    // We search for all entries which read from an address that we write to
+    val wars = entries.map { e => e.valid && (
+      new_entry.dst.overlaps(e.bits.op1) ||
+      new_entry.dst.overlaps(e.bits.op2)
+    )}
+
+    // We search for all entries which write to an address that we write to
+    val waws = entries.map { e => e.valid && 
+      new_entry.dst.overlaps(e.bits.dst)
+    }
+
+    val older_in_same_q = entries.map { e => e.valid && 
+      e.bits.q === new_entry.q && 
+      !e.bits.issued
+    }
+
+    val is_st_and_must_wait_for_prior_ex_config = entries.map { e =>
+      (e.valid && e.bits.q === exq && e.bits.is_config) &&
+      (new_entry.q === stq && !new_entry.is_config)
+    }
+
+    val is_ex_config_and_must_wait_for_prior_st = entries.map { e =>
+      (e.valid && e.bits.q === stq && !e.bits.is_config) &&
+      (new_entry.q === exq && new_entry.is_config)
+    }
+
+    new_entry.deps := (Cat(raws) | 
+                       Cat(wars) | 
+                       Cat(waws) | 
+                       Cat(older_in_same_q) |
+                       Cat(is_st_and_must_wait_for_prior_ex_config) | 
+                       Cat(is_ex_config_and_must_wait_for_prior_st)
+                      ).asBools().reverse
+
+    new_entry.complete_on_issue := new_entry.is_config && new_entry.q =/= exq
+
+    entries(new_entry_id).valid := true.B
+    entries(new_entry_id).bits := new_entry
+
+    last_allocated := new_entry_id
+  }
+
+  // Issue commands which are ready to be issued
+  Seq((ldq, io.issue.load), 
+      (stq, io.issue.store), 
+      (exq, io.issue.exec)).foreach { case (q, io) =>
+    val issue_id = MuxCase((ROB_ENTRIES-1).U, entries.zipWithIndex.map { 
+      case (e, i) => (e.valid && e.bits.ready() && 
+                      !e.bits.issued && e.bits.q === q) -> i.U
+    })
+    io.valid := entries.map(e => e.valid && e.bits.ready() && !e.bits.issued 
+                                 && e.bits.q === q).reduce(_ || _)
+    io.bits.cmd := entries(issue_id).bits.cmd
+    io.bits.rob_id.push(issue_id)
+
+    // ssteff: added for debug
+    when(io.fire()) {
+      //======================================================================
+      // debug
+      //======================================================================
+      when(entries(issue_id).bits.is_config) {
+        when (entries(issue_id).bits.is_load) {
+          printf(
+            "cycle[%d], entry[%d],  issue[%d], config_mvin\n",
+            debug_cycle, issue_id, entries(issue_id).bits.cmd_id)
+          printf(
+            "cycle[%d], entry[%d],  final[%d], config_mvin\n", 
+            debug_cycle, issue_id, entries(issue_id).bits.cmd_id)
+        }
+        .elsewhen (entries(issue_id).bits.is_store) {
+          printf(
+            "cycle[%d], entry[%d],  issue[%d], config_mvout\n",
+            debug_cycle, issue_id, entries(issue_id).bits.cmd_id)
+          printf(
+            "cycle[%d], entry[%d],  final[%d], config_mvout\n", 
+            debug_cycle, issue_id, entries(issue_id).bits.cmd_id)
+        }
+        .otherwise {
+          assert(entries(issue_id).bits.is_exec)
+          printf(
+            "cycle[%d], entry[%d],  issue[%d], config_ex\n",
+            debug_cycle, issue_id, entries(issue_id).bits.cmd_id)
+        }
+      }
+      .elsewhen (entries(issue_id).bits.is_load) {
+        printf(
+          "cycle[%d], entry[%d],  issue[%d], mvin\n",
+          debug_cycle, issue_id, entries(issue_id).bits.cmd_id)
+      }
+      .elsewhen (entries(issue_id).bits.is_store) {
+        printf(
+          "cycle[%d], entry[%d],  issue[%d], mvout\n",
+          debug_cycle, issue_id, entries(issue_id).bits.cmd_id)
+      }
+      .elsewhen (entries(issue_id).bits.is_preload) {
+        printf(
+          "cycle[%d], entry[%d],  issue[%d], preload\n",
+          debug_cycle, issue_id, entries(issue_id).bits.cmd_id)
+      }
+      .otherwise {
+        assert(entries(issue_id).bits.is_exec)
+        printf(
+          "cycle[%d], entry[%d],  issue[%d], ex\n",
+          debug_cycle, issue_id, entries(issue_id).bits.cmd_id)
+      }
+      //======================================================================
+
+      entries(issue_id).bits.issued := true.B
+
+      // Clear out all the dependency bits for instructions which 
+      // depend on the same queue
+      entries.zipWithIndex.foreach { case (e, i) =>
+        val is_same_q = Mux(alloc_fire && new_entry_id === i.U,
+          new_entry.q === entries(issue_id).bits.q,
+          e.bits.q === entries(issue_id).bits.q)
+
+        when (is_same_q || entries(issue_id).bits.complete_on_issue) {
+          e.bits.deps(issue_id) := false.B
+        }
+      }
+
+      entries(issue_id).valid := !entries(issue_id).bits.complete_on_issue
+    }
+  }
+
+  // Mark entries as completed once they've returned
+  when (io.completed.fire()) {
+    //======================================================================
+    // debug
+    //======================================================================
+    //  entries(io.completed.bits).bits.cmd.rs2))
+    when (entries(io.completed.bits).bits.is_config) {
+      assert(entries(io.completed.bits).bits.is_exec)
+      printf(
+        "cycle[%d], entry[%d],  final[%d], config_ex\n",
+        debug_cycle, io.completed.bits, 
+        entries(io.completed.bits).bits.cmd_id)
+    }
+    .elsewhen (entries(io.completed.bits).bits.is_load) {
+      printf(
+        "cycle[%d], entry[%d],  final[%d], mvin\n",
+        debug_cycle, io.completed.bits, 
+        entries(io.completed.bits).bits.cmd_id)
+    }
+    .elsewhen (entries(io.completed.bits).bits.is_store) {
+      printf(
+        "cycle[%d], entry[%d],  final[%d], mvout\n",
+        debug_cycle, io.completed.bits, 
+        entries(io.completed.bits).bits.cmd_id)
+    }
+    .elsewhen (entries(io.completed.bits).bits.is_preload) {
+      printf(
+        "cycle[%d], entry[%d],  final[%d], preload\n",
+        debug_cycle, io.completed.bits, 
+        entries(io.completed.bits).bits.cmd_id)
+    }
+    .otherwise {
+      assert(entries(io.completed.bits).bits.is_exec)
+      printf(
+        "cycle[%d], entry[%d],  final[%d], ex\n",
+        debug_cycle, io.completed.bits, 
+        entries(io.completed.bits).bits.cmd_id)
+    }
+    //======================================================================
+
+    entries.foreach(_.bits.deps(io.completed.bits) := false.B)
+
+    entries(io.completed.bits).valid := false.B
+    assert(entries(io.completed.bits).valid)
+  }
+
+  val util = PopCount(entries.map(e => e.valid))
+  val util_ld_q_unissued = PopCount(entries.map(e => e.valid && 
+                                                     !e.bits.issued && 
+                                                     e.bits.q === ldq))
+  val util_st_q_unissued = PopCount(entries.map(e => e.valid && 
+                                                     !e.bits.issued && 
+                                                     e.bits.q === stq))
+  val util_ex_q_unissued = PopCount(entries.map(e => e.valid && 
+                                                     !e.bits.issued && 
+                                                     e.bits.q === exq))
+  val util_ld_q = PopCount(entries.map(e => e.valid && e.bits.q === ldq))
+  val util_st_q = PopCount(entries.map(e => e.valid && e.bits.q === stq))
+  val util_ex_q = PopCount(entries.map(e => e.valid && e.bits.q === exq))
+
+  val packed_deps = VecInit(entries.map(e => Cat(e.bits.deps)))
+  dontTouch(packed_deps)
+
+  val pop_count_packed_deps = VecInit(entries.map(e => Mux(e.valid, PopCount(e.bits.deps), 0.U)))
+  val min_pop_count = pop_count_packed_deps.reduce((acc, d) => minOf(acc, d))
+  // assert(min_pop_count < 2.U)
+  dontTouch(pop_count_packed_deps)
+  dontTouch(min_pop_count)
+
+  val cycles_since_issue = RegInit(0.U(32.W))
+
+  when (io.issue.load.fire() || 
+        io.issue.store.fire() || 
+        io.issue.exec.fire() || 
+        !io.busy) {
+    cycles_since_issue := 0.U
+  } .elsewhen (io.busy) {
+    cycles_since_issue := cycles_since_issue + 1.U
+  }
+  assert(cycles_since_issue < 10000.U, "pipeline stall")
+
+  val cntr = Counter(10000000)
+  when (cntr.inc()) {
+    printf(p"Utilization: $util\n")
+    printf(p"Utilization ld q (incomplete): $util_ld_q_unissued\n")
+    printf(p"Utilization st q (incomplete): $util_st_q_unissued\n")
+    printf(p"Utilization ex q (incomplete): $util_ex_q_unissued\n")
+    printf(p"Utilization ld q: $util_ld_q\n")
+    printf(p"Utilization st q: $util_st_q\n")
+    printf(p"Utilization ex q: $util_ex_q\n")
+    printf(p"Packed deps: $packed_deps\n")
+    printf(p"Last allocated: $last_allocated\n\n")
+  }
+
+  when (reset.toBool()) {
+    entries.foreach(_.valid := false.B)
+  }
+}
+
+object TilerScheduler {
+  def apply[T <: Data: Arithmetic, U <: Data]
+    (config: GemminiArrayConfig[T,U])(implicit p: Parameters)
+      = Module(new TilerScheduler(config))
+}

--- a/src/main/scala/gemmini/Util.scala
+++ b/src/main/scala/gemmini/Util.scala
@@ -107,4 +107,13 @@ object Util {
   object UDValid {
     def apply[T <: Data](t: T): UDValid[T] = new UDValid(t)
   }
+
+  // creates a Reg and the next-state Wire, and returns both
+  def regwire(bits: Int) = {
+    val wire = Wire(UInt(bits.W))
+    val reg = RegNext(wire)
+    wire := reg // default wire to read from reg
+    (reg, wire)
+  }
+
 }


### PR DESCRIPTION
- gemmini cisc frontend and risc frontend co-exist
- there is currently no way to remove either frontend 
- there are no special instructions to switch between the modes. the risc/cisc mode is inferred from the RoCC funct7 field
- there are mechanisms in the Chisel to prevent the risc/cisc from issuing/commiting instructions at the same time
- verified risc/cisc both work and can switch between on verilator using several gemm-rocc-tests bareMetalC tests
