### PR TITLE
[WIP] Add option to share tilelink port with tile ICache and DCache

### DIFF
--- a/src/main/scala/gemmini/Configs.scala
+++ b/src/main/scala/gemmini/Configs.scala
@@ -88,6 +88,7 @@ object GemminiConfigs {
     // mvin_scale_acc_args = None,
     mvin_scale_acc_args = None,
     mvin_scale_shared = false,
+    use_dedicated_tl_port = false,
     pe_latency = 0
   )
 }

--- a/src/main/scala/gemmini/DSEConfigs.scala
+++ b/src/main/scala/gemmini/DSEConfigs.scala
@@ -38,6 +38,7 @@ object DSEBaseConfig {
     mvin_scale_args = None,
     mvin_scale_acc_args = None,
     mvin_scale_shared = false,
+    use_dedicated_tl_port = false,
     pe_latency = 0
   )
 }

--- a/src/main/scala/gemmini/GemminiConfigs.scala
+++ b/src/main/scala/gemmini/GemminiConfigs.scala
@@ -37,6 +37,7 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data](
                                                                   mvin_scale_args: Option[MvinScaleArguments[T, U]],
                                                                   mvin_scale_acc_args: Option[MvinScaleArguments[T, U]],
                                                                   mvin_scale_shared: Boolean,
+                                                                  use_dedicated_tl_port: Boolean,
                                                                   pe_latency: Int,
                                                                   headerFileName: String = "gemmini_params.h"
                                                        ) {


### PR DESCRIPTION
Provisioning to saturate both Gemmini accesses and core L1 accesses is probably overkill.
Sharing the tilelink port reduces pressure on the system XBar.