### PR TITLE
Add support for dummy configs

### DIFF
--- a/src/main/scala/gemmini/AccumulatorMem.scala
+++ b/src/main/scala/gemmini/AccumulatorMem.scala
@@ -91,7 +91,7 @@ class AccumulatorMem[T <: Data, U <: Data](
   n: Int, t: Vec[Vec[T]], scale_func: (T, U) => T, scale_t: U,
   acc_singleported: Boolean, acc_sub_banks: Int,
   use_shared_ext_mem: Boolean,
-  acc_latency: Int, acc_type: T
+  acc_latency: Int, acc_type: T, is_dummy: Boolean
 )
   (implicit ev: Arithmetic[T]) extends Module {
   // TODO Do writes in this module work with matrices of size 2? If we try to read from an address right after writing
@@ -134,7 +134,7 @@ class AccumulatorMem[T <: Data, U <: Data](
   val mask_len = t.getWidth / 8
   val mask_elem = UInt((t.getWidth / mask_len).W)
 
-  if (!acc_singleported) {
+  if (!acc_singleported && !is_dummy) {
     require(!use_shared_ext_mem)
     val mem = TwoPortSyncMem(n, t, mask_len) // TODO We assume byte-alignment here. Use aligned_to instead
     mem.io.waddr := oldest_pipelined_write.bits.addr
@@ -146,6 +146,9 @@ class AccumulatorMem[T <: Data, U <: Data](
     mem.io.raddr := Mux(io.write.fire && io.write.bits.acc, io.write.bits.addr, io.read.req.bits.addr)
     mem.io.ren := io.read.req.fire || (io.write.fire && io.write.bits.acc)
   } else {
+    mem.io.raddr := Mux(io.write.fire && io.write.bits.acc, io.write.bits.addr, io.read.req.bits.addr)
+    mem.io.ren := io.read.req.fire || (io.write.fire && io.write.bits.acc)
+  } else if (!is_dummy) {
     val rmw_req = Wire(Decoupled(UInt()))
     rmw_req.valid := io.write.valid && io.write.bits.acc
     rmw_req.bits := io.write.bits.addr
@@ -291,8 +294,15 @@ class AccumulatorMem[T <: Data, U <: Data](
     }
   }
 
+
   val q = Module(new Queue(new AccumulatorReadResp(t, scale_t, log2Ceil(t.head.head.getWidth)),  1, true, true))
   q.io.enq.bits.data := rdata_for_read_resp
+
+  if (is_dummy) {
+    rdata_for_read_resp := DontCare
+    rdata_for_adder := DontCare
+  }
+
   q.io.enq.bits.scale := RegNext(io.read.req.bits.scale)
   q.io.enq.bits.relu6_shift := RegNext(io.read.req.bits.relu6_shift)
   q.io.enq.bits.act := RegNext(io.read.req.bits.act)

--- a/src/main/scala/gemmini/AccumulatorMem.scala
+++ b/src/main/scala/gemmini/AccumulatorMem.scala
@@ -289,11 +289,6 @@ class AccumulatorMem[T <: Data, U <: Data](
         w_q.foreach(_.valid := false.B)
       }
     }
-  } else /*if (is_dummy)*/ {
-    // This is just like the dual-ported accumulator, except that we never write
-    // anything into the SRAM.
-    mem.io.raddr := Mux(io.write.fire && io.write.bits.acc, io.write.bits.addr, io.read.req.bits.addr)
-    mem.io.ren := io.read.req.fire || (io.write.fire && io.write.bits.acc)
   }
 
   val q = Module(new Queue(new AccumulatorReadResp(t, scale_t, log2Ceil(t.head.head.getWidth)),  1, true, true))

--- a/src/main/scala/gemmini/Arithmetic.scala
+++ b/src/main/scala/gemmini/Arithmetic.scala
@@ -14,6 +14,15 @@ case class Float(expWidth: Int, sigWidth: Int) extends Bundle {
   val bias: Int = (1 << (expWidth-1)) - 1
 }
 
+case class DummySInt(w: Int) extends Bundle {
+  val bits = UInt(w.W)
+  def dontCare: DummySInt = {
+    val o = Wire(new DummySInt(w))
+    o.bits := 0.U
+    o
+  }
+}
+
 // The Arithmetic typeclass which implements various arithmetic operations on custom datatypes
 abstract class Arithmetic[T <: Data] {
   implicit def cast(t: T): ArithmeticOps[T]
@@ -362,6 +371,22 @@ object Arithmetic {
 
       override def zero: Float = 0.U.asTypeOf(self)
       override def identity: Float = Cat(0.U(2.W), ~(0.U((self.expWidth-1).W)), 0.U((self.sigWidth-1).W)).asTypeOf(self)
+    }
+  }
+
+  implicit object DummySIntArithmetic extends Arithmetic[DummySInt] {
+    override implicit def cast(self: DummySInt) = new ArithmeticOps(self) {
+      override def *(t: DummySInt) = self.dontCare
+      override def mac(m1: DummySInt, m2: DummySInt) = self.dontCare
+      override def +(t: DummySInt) = self.dontCare
+      override def >>(t: UInt) = self.dontCare
+      override def >(t: DummySInt): Bool = false.B
+      override def identity = self.dontCare
+      override def withWidthOf(t: DummySInt) = self.dontCare
+      override def clippedToWidthOf(t: DummySInt) = self.dontCare
+      override def relu = self.dontCare
+      override def relu6(shift: UInt) = self.dontCare
+      override def zero = self.dontCare
     }
   }
 }

--- a/src/main/scala/gemmini/Configs.scala
+++ b/src/main/scala/gemmini/Configs.scala
@@ -164,6 +164,63 @@ object GemminiConfigs {
     ex_write_to_acc = true,
   )
 
+  val dummyConfig = GemminiArrayConfig[DummySInt, Float, Float](
+    inputType = DummySInt(8),
+    accType = DummySInt(32),
+    spatialArrayOutputType = DummySInt(20),
+    tileRows     = defaultConfig.tileRows,
+    tileColumns  = defaultConfig.tileColumns,
+    meshRows     = defaultConfig.meshRows,
+    meshColumns  = defaultConfig.meshColumns,
+    dataflow     = defaultConfig.dataflow,
+    sp_capacity  = defaultConfig.sp_capacity,
+    acc_capacity = defaultConfig.acc_capacity,
+    sp_banks     = defaultConfig.sp_banks,
+    acc_banks    = defaultConfig.acc_banks,
+    sp_singleported = defaultConfig.sp_singleported,
+    acc_singleported = defaultConfig.acc_singleported,
+    has_training_convs = defaultConfig.has_training_convs,
+    has_max_pool = defaultConfig.has_max_pool,
+    has_nonlinear_activations = defaultConfig.has_nonlinear_activations,
+    reservation_station_full_entries = defaultConfig.reservation_station_full_entries,
+    reservation_station_partial_entries = defaultConfig.reservation_station_partial_entries,
+    ld_queue_length = defaultConfig.ld_queue_length,
+    st_queue_length = defaultConfig.st_queue_length,
+    ex_queue_length = defaultConfig.ex_queue_length,
+    max_in_flight_mem_reqs = defaultConfig.max_in_flight_mem_reqs,
+    dma_maxbytes = defaultConfig.dma_maxbytes,
+    dma_buswidth = defaultConfig.dma_buswidth,
+    tlb_size = defaultConfig.tlb_size,
+
+    mvin_scale_args = Some(ScaleArguments(
+      (t: DummySInt, f: Float) => t.dontCare,
+      4, Float(8, 24), 4,
+      identity = "1.0",
+      c_str = "({float y = ROUND_NEAR_EVEN((x) * (scale)); y > INT8_MAX ? INT8_MAX : (y < INT8_MIN ? INT8_MIN : (elem_t)y);})"
+    )),
+
+    mvin_scale_acc_args = None,
+    mvin_scale_shared = defaultConfig.mvin_scale_shared,
+
+    acc_scale_args = Some(ScaleArguments(
+      (t: DummySInt, f: Float) => t.dontCare,
+      1, Float(8, 24), -1,
+      identity = "1.0",
+      c_str = "({float y = ROUND_NEAR_EVEN((x) * (scale)); y > INT8_MAX ? INT8_MAX : (y < INT8_MIN ? INT8_MIN : (acc_t)y);})"
+    )),
+
+    num_counter = defaultConfig.num_counter,
+
+    acc_read_full_width = defaultConfig.acc_read_full_width,
+    acc_read_small_width = defaultConfig.acc_read_small_width,
+
+    ex_read_from_spad = defaultConfig.ex_read_from_spad,
+    ex_read_from_acc = defaultConfig.ex_read_from_acc,
+    ex_write_to_spad = defaultConfig.ex_write_to_spad,
+    ex_write_to_acc = defaultConfig.ex_write_to_acc,
+  )
+
+
   val chipConfig = defaultConfig.copy(sp_capacity=CapacityInKilobytes(64), acc_capacity=CapacityInKilobytes(32), dataflow=Dataflow.WS,
     acc_scale_args=Some(defaultConfig.acc_scale_args.get.copy(latency=4)),
     acc_singleported=true,

--- a/src/main/scala/gemmini/Configs.scala
+++ b/src/main/scala/gemmini/Configs.scala
@@ -182,8 +182,9 @@ object GemminiConfigs {
     has_training_convs = defaultConfig.has_training_convs,
     has_max_pool = defaultConfig.has_max_pool,
     has_nonlinear_activations = defaultConfig.has_nonlinear_activations,
-    reservation_station_full_entries = defaultConfig.reservation_station_full_entries,
-    reservation_station_partial_entries = defaultConfig.reservation_station_partial_entries,
+    reservation_station_entries_ld = defaultConfig.reservation_station_entries_ld
+    reservation_station_entries_st = defaultConfig.reservation_station_entries_st
+    reservation_station_entries_ex = defaultConfig.reservation_station_entries_ex
     ld_queue_length = defaultConfig.ld_queue_length,
     st_queue_length = defaultConfig.st_queue_length,
     ex_queue_length = defaultConfig.ex_queue_length,
@@ -219,7 +220,6 @@ object GemminiConfigs {
     ex_write_to_spad = defaultConfig.ex_write_to_spad,
     ex_write_to_acc = defaultConfig.ex_write_to_acc,
   )
-
 
   val chipConfig = defaultConfig.copy(sp_capacity=CapacityInKilobytes(64), acc_capacity=CapacityInKilobytes(32), dataflow=Dataflow.WS,
     acc_scale_args=Some(defaultConfig.acc_scale_args.get.copy(latency=4)),

--- a/src/main/scala/gemmini/Configs.scala
+++ b/src/main/scala/gemmini/Configs.scala
@@ -182,9 +182,9 @@ object GemminiConfigs {
     has_training_convs = defaultConfig.has_training_convs,
     has_max_pool = defaultConfig.has_max_pool,
     has_nonlinear_activations = defaultConfig.has_nonlinear_activations,
-    reservation_station_entries_ld = defaultConfig.reservation_station_entries_ld
-    reservation_station_entries_st = defaultConfig.reservation_station_entries_st
-    reservation_station_entries_ex = defaultConfig.reservation_station_entries_ex
+    reservation_station_entries_ld = defaultConfig.reservation_station_entries_ld,
+    reservation_station_entries_st = defaultConfig.reservation_station_entries_st,
+    reservation_station_entries_ex = defaultConfig.reservation_station_entries_ex,
     ld_queue_length = defaultConfig.ld_queue_length,
     st_queue_length = defaultConfig.st_queue_length,
     ex_queue_length = defaultConfig.ex_queue_length,

--- a/src/main/scala/gemmini/GemminiConfigs.scala
+++ b/src/main/scala/gemmini/GemminiConfigs.scala
@@ -173,6 +173,8 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data, V <: Data](
 
   val tree_reduction = use_tree_reduction_if_possible && dataflow == Dataflow.WS && tileRows > 1
 
+  val is_dummy = inputType.isInstanceOf[DummySInt]
+
   //==========================================================================
   // sanity check mesh size
   //==========================================================================
@@ -276,6 +278,7 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data, V <: Data](
 
       dataType match {
         case dt: SInt => ("-" + BigInt(2).pow(dt.getWidth - 1).toString, BigInt(2).pow(dt.getWidth - 1).-(1).toString)
+        case dt: DummySInt => ("-" + BigInt(2).pow(dt.getWidth - 1).toString, BigInt(2).pow(dt.getWidth - 1).-(1).toString)
         case dt: Float =>
           (dt.expWidth, dt.sigWidth) match {
             case (8, 24) => (scala.Float.MinValue.toString, scala.Float.MaxValue.toString)
@@ -290,6 +293,7 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data, V <: Data](
     def c_type(dataType: Data): String = {
       dataType match {
         case dt: SInt => s"int${dt.getWidth}_t"
+        case dt: DummySInt => s"int${dt.getWidth}_t"
         case dt: Float =>
           (dt.expWidth, dt.sigWidth) match {
             case (8, 24) => "float"
@@ -304,9 +308,9 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data, V <: Data](
       dataType match {
         case _: UInt => "uint64_t"
         case _: SInt => "int64_t"
+        case _: DummySInt => "int64_t"
         case _: Float => "double"
         case _ => "uint64_t"
-        // case _ => throw new IllegalArgumentException(s"Data type $dataType is unknown")
       }
     }
 


### PR DESCRIPTION
This PR adds a new Arithmetic datatype, `DummySInt`, that does not generate any compute, and hardwires the memories to 0. 
The `dummyConfig` is useful for testing performance of a SInt config when correctness is known, as this config will otherwise behave identically.