### PR TITLE
Bump Gemmini to v0.6.4

### DIFF
--- a/scripts/build-vcs.sh
+++ b/scripts/build-vcs.sh
@@ -13,12 +13,12 @@ help () {
 }
 
 show_help=0
-DEBUG=""
+debug=""
 
 while [ $# -gt 0 ] ; do
   case $1 in
     -h | --help) show_help=1 ;;
-    --debug) DEBUG="debug"
+    --debug) debug="debug"
   esac
 
   shift

--- a/scripts/build-verilator.sh
+++ b/scripts/build-verilator.sh
@@ -13,12 +13,12 @@ help () {
 }
 
 show_help=0
-DEBUG=""
+debug=""
 
 while [ $# -gt 0 ] ; do
   case $1 in
     -h | --help) show_help=1 ;;
-    --debug) DEBUG="debug"
+    --debug) debug="debug"
   esac
 
   shift

--- a/src/main/scala/gemmini/AccumulatorMem.scala
+++ b/src/main/scala/gemmini/AccumulatorMem.scala
@@ -91,7 +91,7 @@ class AccumulatorMem[T <: Data, U <: Data](
   n: Int, t: Vec[Vec[T]], scale_func: (T, U) => T, scale_t: U,
   acc_singleported: Boolean, acc_sub_banks: Int,
   use_shared_ext_mem: Boolean,
-  acc_latency: Int, acc_type: T
+  acc_latency: Int, acc_type: T, is_dummy: Boolean
 )
   (implicit ev: Arithmetic[T]) extends Module {
   // TODO Do writes in this module work with matrices of size 2? If we try to read from an address right after writing
@@ -134,7 +134,7 @@ class AccumulatorMem[T <: Data, U <: Data](
   val mask_len = t.getWidth / 8
   val mask_elem = UInt((t.getWidth / mask_len).W)
 
-  if (!acc_singleported) {
+  if (!acc_singleported && !is_dummy) {
     require(!use_shared_ext_mem)
     val mem = TwoPortSyncMem(n, t, mask_len) // TODO We assume byte-alignment here. Use aligned_to instead
     mem.io.waddr := oldest_pipelined_write.bits.addr
@@ -145,7 +145,7 @@ class AccumulatorMem[T <: Data, U <: Data](
     rdata_for_read_resp := mem.io.rdata
     mem.io.raddr := Mux(io.write.fire && io.write.bits.acc, io.write.bits.addr, io.read.req.bits.addr)
     mem.io.ren := io.read.req.fire || (io.write.fire && io.write.bits.acc)
-  } else {
+  } else if (!is_dummy) {
     val rmw_req = Wire(Decoupled(UInt()))
     rmw_req.valid := io.write.valid && io.write.bits.acc
     rmw_req.bits := io.write.bits.addr
@@ -293,6 +293,12 @@ class AccumulatorMem[T <: Data, U <: Data](
 
   val q = Module(new Queue(new AccumulatorReadResp(t, scale_t, log2Ceil(t.head.head.getWidth)),  1, true, true))
   q.io.enq.bits.data := rdata_for_read_resp
+
+  if (is_dummy) {
+    rdata_for_read_resp := DontCare
+    rdata_for_adder := DontCare
+  }
+
   q.io.enq.bits.scale := RegNext(io.read.req.bits.scale)
   q.io.enq.bits.relu6_shift := RegNext(io.read.req.bits.relu6_shift)
   q.io.enq.bits.act := RegNext(io.read.req.bits.act)

--- a/src/main/scala/gemmini/Arithmetic.scala
+++ b/src/main/scala/gemmini/Arithmetic.scala
@@ -14,6 +14,15 @@ case class Float(expWidth: Int, sigWidth: Int) extends Bundle {
   val bias: Int = (1 << (expWidth-1)) - 1
 }
 
+case class DummySInt(w: Int) extends Bundle {
+  val bits = UInt(w.W)
+  def dontCare: DummySInt = {
+    val o = Wire(new DummySInt(w))
+    o.bits := 0.U
+    o
+  }
+}
+
 // The Arithmetic typeclass which implements various arithmetic operations on custom datatypes
 abstract class Arithmetic[T <: Data] {
   implicit def cast(t: T): ArithmeticOps[T]
@@ -362,6 +371,22 @@ object Arithmetic {
 
       override def zero: Float = 0.U.asTypeOf(self)
       override def identity: Float = Cat(0.U(2.W), ~(0.U((self.expWidth-1).W)), 0.U((self.sigWidth-1).W)).asTypeOf(self)
+    }
+  }
+
+  implicit object DummySIntArithmetic extends Arithmetic[DummySInt] {
+    override implicit def cast(self: DummySInt) = new ArithmeticOps(self) {
+      override def *(t: DummySInt) = self.dontCare
+      override def mac(m1: DummySInt, m2: DummySInt) = self.dontCare
+      override def +(t: DummySInt) = self.dontCare
+      override def >>(t: UInt) = self.dontCare
+      override def >(t: DummySInt): Bool = false.B
+      override def identity = self.dontCare
+      override def withWidthOf(t: DummySInt) = self.dontCare
+      override def clippedToWidthOf(t: DummySInt) = self.dontCare
+      override def relu = self.dontCare
+      override def relu6(shift: UInt) = self.dontCare
+      override def zero = self.dontCare
     }
   }
 }

--- a/src/main/scala/gemmini/Configs.scala
+++ b/src/main/scala/gemmini/Configs.scala
@@ -164,6 +164,63 @@ object GemminiConfigs {
     ex_write_to_acc = true,
   )
 
+  val dummyConfig = GemminiArrayConfig[DummySInt, Float, Float](
+    inputType = DummySInt(8),
+    accType = DummySInt(32),
+    spatialArrayOutputType = DummySInt(20),
+    tileRows     = defaultConfig.tileRows,
+    tileColumns  = defaultConfig.tileColumns,
+    meshRows     = defaultConfig.meshRows,
+    meshColumns  = defaultConfig.meshColumns,
+    dataflow     = defaultConfig.dataflow,
+    sp_capacity  = defaultConfig.sp_capacity,
+    acc_capacity = defaultConfig.acc_capacity,
+    sp_banks     = defaultConfig.sp_banks,
+    acc_banks    = defaultConfig.acc_banks,
+    sp_singleported = defaultConfig.sp_singleported,
+    acc_singleported = defaultConfig.acc_singleported,
+    has_training_convs = defaultConfig.has_training_convs,
+    has_max_pool = defaultConfig.has_max_pool,
+    has_nonlinear_activations = defaultConfig.has_nonlinear_activations,
+    reservation_station_entries_ld = defaultConfig.reservation_station_entries_ld,
+    reservation_station_entries_st = defaultConfig.reservation_station_entries_st,
+    reservation_station_entries_ex = defaultConfig.reservation_station_entries_ex,
+    ld_queue_length = defaultConfig.ld_queue_length,
+    st_queue_length = defaultConfig.st_queue_length,
+    ex_queue_length = defaultConfig.ex_queue_length,
+    max_in_flight_mem_reqs = defaultConfig.max_in_flight_mem_reqs,
+    dma_maxbytes = defaultConfig.dma_maxbytes,
+    dma_buswidth = defaultConfig.dma_buswidth,
+    tlb_size = defaultConfig.tlb_size,
+
+    mvin_scale_args = Some(ScaleArguments(
+      (t: DummySInt, f: Float) => t.dontCare,
+      4, Float(8, 24), 4,
+      identity = "1.0",
+      c_str = "({float y = ROUND_NEAR_EVEN((x) * (scale)); y > INT8_MAX ? INT8_MAX : (y < INT8_MIN ? INT8_MIN : (elem_t)y);})"
+    )),
+
+    mvin_scale_acc_args = None,
+    mvin_scale_shared = defaultConfig.mvin_scale_shared,
+
+    acc_scale_args = Some(ScaleArguments(
+      (t: DummySInt, f: Float) => t.dontCare,
+      1, Float(8, 24), -1,
+      identity = "1.0",
+      c_str = "({float y = ROUND_NEAR_EVEN((x) * (scale)); y > INT8_MAX ? INT8_MAX : (y < INT8_MIN ? INT8_MIN : (acc_t)y);})"
+    )),
+
+    num_counter = defaultConfig.num_counter,
+
+    acc_read_full_width = defaultConfig.acc_read_full_width,
+    acc_read_small_width = defaultConfig.acc_read_small_width,
+
+    ex_read_from_spad = defaultConfig.ex_read_from_spad,
+    ex_read_from_acc = defaultConfig.ex_read_from_acc,
+    ex_write_to_spad = defaultConfig.ex_write_to_spad,
+    ex_write_to_acc = defaultConfig.ex_write_to_acc,
+  )
+
   val chipConfig = defaultConfig.copy(sp_capacity=CapacityInKilobytes(64), acc_capacity=CapacityInKilobytes(32), dataflow=Dataflow.WS,
     acc_scale_args=Some(defaultConfig.acc_scale_args.get.copy(latency=4)),
     acc_singleported=true,

--- a/src/main/scala/gemmini/Configs.scala
+++ b/src/main/scala/gemmini/Configs.scala
@@ -51,8 +51,9 @@ object GemminiConfigs {
     has_nonlinear_activations = true,
 
     // Reservation station entries
-    reservation_station_full_entries = 16,
-    reservation_station_partial_entries = 8,
+    reservation_station_entries_ld = 8,
+    reservation_station_entries_st = 4,
+    reservation_station_entries_ex = 16,
 
     // Ld/Ex/St instruction queue lengths
     ld_queue_length = 8,

--- a/src/main/scala/gemmini/ConfigsFP.scala
+++ b/src/main/scala/gemmini/ConfigsFP.scala
@@ -24,8 +24,9 @@ object GemminiFPConfigs {
     st_queue_length = 2,
     ex_queue_length = 8,
 
-    reservation_station_full_entries = 16,
-    reservation_station_partial_entries = 8,
+    reservation_station_entries_ld = 8,
+    reservation_station_entries_st = 4,
+    reservation_station_entries_ex = 16,
 
     sp_banks = 4,
     sp_singleported = true,

--- a/src/main/scala/gemmini/Controller.scala
+++ b/src/main/scala/gemmini/Controller.scala
@@ -17,7 +17,8 @@ import Util._
 class GemminiCmd(rob_entries: Int)(implicit p: Parameters) extends Bundle {
   val cmd = new RoCCCommand
   val rob_id = UDValid(UInt(log2Up(rob_entries).W))
-
+  val from_matmul_fsm = Bool()
+  val from_conv_fsm = Bool()
 }
 
 class Gemmini[T <: Data : Arithmetic, U <: Data, V <: Data](val config: GemminiArrayConfig[T, U, V])
@@ -120,21 +121,29 @@ class GemminiModule[T <: Data: Arithmetic, U <: Data, V <: Data]
   val unrolled_cmd = LoopUnroller(raw_risc_cmd, outer.config.meshRows * outer.config.tileRows)
   */
 
-  val reservation_station = withClock (gated_clock) { Module(new ReservationStation(outer.config, new RoCCCommand)) }
+  val reservation_station = withClock (gated_clock) { Module(new ReservationStation(outer.config, new GemminiCmd(reservation_station_entries))) }
   counters.io.event_io.collect(reservation_station.io.counter)
 
   when (io.cmd.valid && io.cmd.bits.inst.funct === CLKGATE_EN && !io.busy) {
     clock_en_reg := io.cmd.bits.rs1(0)
   }
-  val raw_cmd = Queue(io.cmd)
 
-  val max_lds = reservation_station_partial_entries
-  val max_exs = reservation_station_full_entries
-  val max_sts = reservation_station_partial_entries / 2
+  val raw_cmd_q = Module(new Queue(new GemminiCmd(reservation_station_entries), entries = 2))
+  raw_cmd_q.io.enq.valid := io.cmd.valid
+  io.cmd.ready := raw_cmd_q.io.enq.ready
+  raw_cmd_q.io.enq.bits.cmd := io.cmd.bits
+  raw_cmd_q.io.enq.bits.rob_id := DontCare
+  raw_cmd_q.io.enq.bits.from_conv_fsm := false.B
+  raw_cmd_q.io.enq.bits.from_matmul_fsm := false.B
 
-  // TODO replace 4,12,2 with parameters based on ROB size
-  val (conv_cmd, loop_conv_unroller_busy) = withClock (gated_clock) { LoopConv(raw_cmd, reservation_station.io.ld_utilization, reservation_station.io.st_utilization, reservation_station.io.ex_utilization,
-    meshRows*tileRows, coreMaxAddrBits, rob_entries, max_lds, max_exs, max_sts, sp_banks * sp_bank_entries, acc_banks * acc_bank_entries,
+  val raw_cmd = raw_cmd_q.io.deq
+
+  val max_lds = reservation_station_entries_ld
+  val max_exs = reservation_station_entries_ex
+  val max_sts = reservation_station_entries_st
+
+  val (conv_cmd, loop_conv_unroller_busy) = withClock (gated_clock) { LoopConv(raw_cmd, reservation_station.io.conv_ld_completed, reservation_station.io.conv_st_completed, reservation_station.io.conv_ex_completed,
+    meshRows*tileRows, coreMaxAddrBits, reservation_station_entries, max_lds, max_exs, max_sts, sp_banks * sp_bank_entries, acc_banks * acc_bank_entries,
     inputType.getWidth, accType.getWidth, dma_maxbytes,
     new ConfigMvinRs1(mvin_scale_t_bits, block_stride_bits, pixel_repeats_bits), new MvinRs2(mvin_rows_bits, mvin_cols_bits, local_addr_t),
     new ConfigMvoutRs2(acc_scale_t_bits, 32), new MvoutRs2(mvout_rows_bits, mvout_cols_bits, local_addr_t),
@@ -143,8 +152,8 @@ class GemminiModule[T <: Data: Arithmetic, U <: Data, V <: Data]
     new ComputeRs(mvin_rows_bits, mvin_cols_bits, local_addr_t), new ComputeRs(mvin_rows_bits, mvin_cols_bits, local_addr_t),
     has_training_convs, has_max_pool, has_first_layer_optimizations) }
 
-  val (loop_cmd, loop_matmul_unroller_busy) = withClock (gated_clock) { LoopMatmul(conv_cmd, reservation_station.io.ld_utilization, reservation_station.io.st_utilization, reservation_station.io.ex_utilization,
-    meshRows*tileRows, coreMaxAddrBits, rob_entries, max_lds, max_exs, max_sts, sp_banks * sp_bank_entries, acc_banks * acc_bank_entries,
+  val (loop_cmd, loop_matmul_unroller_busy) = withClock (gated_clock) { LoopMatmul(conv_cmd, reservation_station.io.matmul_ld_completed, reservation_station.io.matmul_st_completed, reservation_station.io.matmul_ex_completed,
+    meshRows*tileRows, coreMaxAddrBits, reservation_station_entries, max_lds, max_exs, max_sts, sp_banks * sp_bank_entries, acc_banks * acc_bank_entries,
     inputType.getWidth, accType.getWidth, dma_maxbytes, new MvinRs2(mvin_rows_bits, mvin_cols_bits, local_addr_t),
     new PreloadRs(mvin_rows_bits, mvin_cols_bits, local_addr_t), new PreloadRs(mvout_rows_bits, mvout_cols_bits, local_addr_t),
     new ComputeRs(mvin_rows_bits, mvin_cols_bits, local_addr_t), new ComputeRs(mvin_rows_bits, mvin_cols_bits, local_addr_t),
@@ -223,20 +232,17 @@ class GemminiModule[T <: Data: Arithmetic, U <: Data, V <: Data]
 
   load_controller.io.cmd.valid := reservation_station.io.issue.ld.valid
   reservation_station.io.issue.ld.ready := load_controller.io.cmd.ready
-  load_controller.io.cmd.bits.cmd := reservation_station.io.issue.ld.cmd
-  load_controller.io.cmd.bits.cmd.inst.funct := reservation_station.io.issue.ld.cmd.inst.funct
+  load_controller.io.cmd.bits := reservation_station.io.issue.ld.cmd
   load_controller.io.cmd.bits.rob_id.push(reservation_station.io.issue.ld.rob_id)
 
   store_controller.io.cmd.valid := reservation_station.io.issue.st.valid
   reservation_station.io.issue.st.ready := store_controller.io.cmd.ready
-  store_controller.io.cmd.bits.cmd := reservation_station.io.issue.st.cmd
-  store_controller.io.cmd.bits.cmd.inst.funct := reservation_station.io.issue.st.cmd.inst.funct
+  store_controller.io.cmd.bits := reservation_station.io.issue.st.cmd
   store_controller.io.cmd.bits.rob_id.push(reservation_station.io.issue.st.rob_id)
 
   ex_controller.io.cmd.valid := reservation_station.io.issue.ex.valid
   reservation_station.io.issue.ex.ready := ex_controller.io.cmd.ready
-  ex_controller.io.cmd.bits.cmd := reservation_station.io.issue.ex.cmd
-  ex_controller.io.cmd.bits.cmd.inst.funct := reservation_station.io.issue.ex.cmd.inst.funct
+  ex_controller.io.cmd.bits := reservation_station.io.issue.ex.cmd
   ex_controller.io.cmd.bits.rob_id.push(reservation_station.io.issue.ex.rob_id)
 
   // Wire up scratchpad to controllers
@@ -303,7 +309,7 @@ class GemminiModule[T <: Data: Arithmetic, U <: Data, V <: Data]
 
   //-------------------------------------------------------------------------
   // risc
-  val reservation_station_completed_arb = Module(new Arbiter(UInt(log2Up(rob_entries).W), 3))
+  val reservation_station_completed_arb = Module(new Arbiter(UInt(log2Up(reservation_station_entries).W), 3))
 
   reservation_station_completed_arb.io.in(0).valid := ex_controller.io.completed.valid
   reservation_station_completed_arb.io.in(0).bits := ex_controller.io.completed.bits
@@ -353,7 +359,7 @@ class GemminiModule[T <: Data: Arithmetic, U <: Data, V <: Data]
     // val config_cmd_type = cmd.bits.rs1(1,0) // TODO magic numbers
 
     //val funct = unrolled_cmd.bits.inst.funct
-    val risc_funct = unrolled_cmd.bits.inst.funct
+    val risc_funct = unrolled_cmd.bits.cmd.inst.funct
 
     val is_flush = risc_funct === FLUSH_CMD
     val is_counter_op = risc_funct === COUNTER_OP
@@ -367,7 +373,7 @@ class GemminiModule[T <: Data: Arithmetic, U <: Data, V <: Data]
     */
 
     when (is_flush) {
-      val skip = unrolled_cmd.bits.rs1(0)
+      val skip = unrolled_cmd.bits.cmd.rs1(0)
       tlb.io.exp.foreach(_.flush_skip := skip)
       tlb.io.exp.foreach(_.flush_retry := !skip)
 
@@ -376,7 +382,9 @@ class GemminiModule[T <: Data: Arithmetic, U <: Data, V <: Data]
 
     .elsewhen (is_counter_op) {
       // If this is a counter access/configuration command, execute immediately
-      counters.io.in <> unrolled_cmd
+      counters.io.in.valid := unrolled_cmd.valid
+      unrolled_cmd.ready := counters.io.in.ready
+      counters.io.in.bits := unrolled_cmd.bits.cmd
     }
 
     .elsewhen (is_clock_gate_en) {
@@ -393,6 +401,15 @@ class GemminiModule[T <: Data: Arithmetic, U <: Data, V <: Data]
     }
 
   }
+
+  // Debugging signals
+  val pipeline_stall_counter = RegInit(0.U(32.W))
+  when (io.cmd.fire()) {
+    pipeline_stall_counter := 0.U
+  }.elsewhen(io.busy) {
+    pipeline_stall_counter := pipeline_stall_counter + 1.U
+  }
+  assert(pipeline_stall_counter < 10000000.U, "pipeline stall")
 
   /*
   //=========================================================================

--- a/src/main/scala/gemmini/Controller.scala
+++ b/src/main/scala/gemmini/Controller.scala
@@ -325,8 +325,6 @@ class GemminiModule[T <: Data: Arithmetic, U <: Data, V <: Data]
 
   io.interrupt := tlb.io.exp.map(_.interrupt).reduce(_ || _)
 
-  reservation_station.io.solitary_preload := ex_controller.io.solitary_preload
-
   // assert(!io.interrupt, "Interrupt handlers have not been written yet")
 
   // Cycle counters

--- a/src/main/scala/gemmini/DSEConfigs.scala
+++ b/src/main/scala/gemmini/DSEConfigs.scala
@@ -21,10 +21,12 @@ object DSEBaseConfig {
     ld_queue_length = 4,
     st_queue_length = 2,
     ex_queue_length = 8,
-    reservation_station_full_entries = 8,
-    reservation_station_partial_entries = 1,
+    reservation_station_entries_ld = 8,
+    reservation_station_entries_st = 4,
+    reservation_station_entries_ex = 16,
 
-    sp_banks = 4, // TODO support one-bank designs
+
+  sp_banks = 4, // TODO support one-bank designs
     acc_banks = 1,
     acc_singleported = false,
     acc_latency = 2,

--- a/src/main/scala/gemmini/ExecuteController.scala
+++ b/src/main/scala/gemmini/ExecuteController.scala
@@ -43,7 +43,6 @@ class ExecuteController[T <: Data, U <: Data, V <: Data](xLen: Int, tagWidth: In
 
     val completed = Valid(UInt(log2Up(rob_entries).W))
     val busy = Output(Bool())
-    val solitary_preload = Output(Bool()) // TODO very hacky. for ROB, to prevent infinite fence stalls. remove later
 
     val counter = new CounterEventIO()
   })
@@ -69,8 +68,6 @@ class ExecuteController[T <: Data, U <: Data, V <: Data](xLen: Int, tagWidth: In
   // val (cmd, _) = MultiHeadedQueue(io.cmd, ex_queue_length, cmd_q_heads)
   val (cmd, _) = MultiHeadedQueue(unrolled_cmd, ex_queue_length, cmd_q_heads)
   cmd.pop := 0.U
-
-  io.solitary_preload := cmd.valid(0) && cmd.bits(0).cmd.inst.funct === PRELOAD_CMD && !cmd.valid(1)
 
   // STATE defines
   val waiting_for_cmd :: compute :: flush :: flushing :: Nil = Enum(4)

--- a/src/main/scala/gemmini/ExecuteController.scala
+++ b/src/main/scala/gemmini/ExecuteController.scala
@@ -15,7 +15,7 @@ class ExecuteController[T <: Data, U <: Data, V <: Data](xLen: Int, tagWidth: In
   import ev._
 
   val io = IO(new Bundle {
-    val cmd = Flipped(Decoupled(new GemminiCmd(rob_entries)))
+    val cmd = Flipped(Decoupled(new GemminiCmd(reservation_station_entries)))
 
     val im2col = new Bundle {
       val req = Decoupled(new Im2ColReadReq(config))
@@ -41,7 +41,7 @@ class ExecuteController[T <: Data, U <: Data, V <: Data](xLen: Int, tagWidth: In
       val write = Vec(acc_banks, Decoupled(new AccumulatorWriteReq(acc_bank_entries, Vec(meshColumns, Vec(tileColumns, accType)))))
     }
 
-    val completed = Valid(UInt(log2Up(rob_entries).W))
+    val completed = Valid(UInt(log2Up(reservation_station_entries).W))
     val busy = Output(Bool())
 
     val counter = new CounterEventIO()
@@ -50,7 +50,7 @@ class ExecuteController[T <: Data, U <: Data, V <: Data](xLen: Int, tagWidth: In
   val block_size = meshRows*tileRows
 
   val mesh_tag = new Bundle with TagQueueTag {
-    val rob_id = UDValid(UInt(log2Up(rob_entries).W))
+    val rob_id = UDValid(UInt(log2Up(reservation_station_entries).W))
     val addr = local_addr_t.cloneType
     val rows = UInt(log2Up(block_size + 1).W)
     val cols = UInt(log2Up(block_size + 1).W)
@@ -173,7 +173,7 @@ class ExecuteController[T <: Data, U <: Data, V <: Data](xLen: Int, tagWidth: In
   io.completed.bits := DontCare
 
   // val pending_completed_rob_id = Reg(UDValid(UInt(log2Up(rob_entries).W)))
-  val pending_completed_rob_ids = Reg(Vec(2, UDValid(UInt(log2Up(rob_entries).W))))
+  val pending_completed_rob_ids = Reg(Vec(2, UDValid(UInt(log2Up(reservation_station_entries).W))))
 
   // Instantiate a queue which queues up signals which must be fed into the mesh
   val mesh_cntl_signals_q = Module(new Queue(new ComputeCntlSignals, spad_read_delay+1,
@@ -735,7 +735,7 @@ class ExecuteController[T <: Data, U <: Data, V <: Data](xLen: Int, tagWidth: In
 
     val total_rows = UInt(log2Up(block_size + 1).W)
 
-    val rob_id = UDValid(UInt(log2Up(rob_entries).W))
+    val rob_id = UDValid(UInt(log2Up(reservation_station_entries).W))
 
     val dataflow = UInt(1.W)
     val prop = UInt(1.W)

--- a/src/main/scala/gemmini/GemminiConfigs.scala
+++ b/src/main/scala/gemmini/GemminiConfigs.scala
@@ -1,7 +1,7 @@
 
 package gemmini
 
-import scala.math.{pow,sqrt}
+import scala.math.{max, pow, sqrt}
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.tile._
@@ -32,8 +32,9 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data, V <: Data](
                                                                              st_queue_length: Int = 2,
                                                                              ex_queue_length: Int = 8,
 
-                                                                             reservation_station_full_entries: Int = 16,
-                                                                             reservation_station_partial_entries: Int = 8,
+                                                                             reservation_station_entries_ld: Int = 8,
+                                                                             reservation_station_entries_st: Int = 4,
+                                                                             reservation_station_entries_ex: Int = 16,
 
                                                                              sp_banks: Int = 4, // TODO support one-bank designs
                                                                              sp_singleported: Boolean = false,
@@ -187,9 +188,13 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data, V <: Data](
   //==========================================================================
   // cisc-gemmini miscellaneous constants (some redundant with above)
   //==========================================================================
-  val rob_entries      = reservation_station_full_entries + reservation_station_partial_entries
-  val ROB_ENTRIES      = rob_entries
-  val LOG2_ROB_ENTRIES = log2Up(rob_entries)
+  val res_max_per_type = max(reservation_station_entries_ld,
+                         max(reservation_station_entries_st, reservation_station_entries_ex))
+  val reservation_station_entries      = res_max_per_type * 3
+  val ROB_ENTRIES      = reservation_station_entries
+  val ROB_ID_WIDTH     = 2 + log2Up(res_max_per_type)
+  val LOG2_ROB_ENTRIES = ROB_ID_WIDTH
+  // assuming 3 queues (load/store/execute), enum takes 2 bits
 
   //==========================================================================
   // cisc-gemmini hardware-specific compile-time global constants

--- a/src/main/scala/gemmini/GemminiConfigs.scala
+++ b/src/main/scala/gemmini/GemminiConfigs.scala
@@ -173,6 +173,8 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data, V <: Data](
 
   val tree_reduction = use_tree_reduction_if_possible && dataflow == Dataflow.WS && tileRows > 1
 
+  val is_dummy = inputType.isInstanceOf[DummySInt]
+
   //==========================================================================
   // sanity check mesh size
   //==========================================================================
@@ -276,6 +278,7 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data, V <: Data](
 
       dataType match {
         case dt: SInt => ("-" + BigInt(2).pow(dt.getWidth - 1).toString, BigInt(2).pow(dt.getWidth - 1).-(1).toString)
+        case dt: DummySInt => ("-" + BigInt(2).pow(dt.getWidth - 1).toString, BigInt(2).pow(dt.getWidth - 1).-(1).toString)
         case dt: Float =>
           (dt.expWidth, dt.sigWidth) match {
             case (8, 24) => (scala.Float.MinValue.toString, scala.Float.MaxValue.toString)
@@ -290,6 +293,7 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data, V <: Data](
     def c_type(dataType: Data): String = {
       dataType match {
         case dt: SInt => s"int${dt.getWidth}_t"
+        case dt: DummySInt => s"int${dt.getWidth}_t"
         case dt: Float =>
           (dt.expWidth, dt.sigWidth) match {
             case (8, 24) => "float"
@@ -304,9 +308,9 @@ case class GemminiArrayConfig[T <: Data : Arithmetic, U <: Data, V <: Data](
       dataType match {
         case _: UInt => "uint64_t"
         case _: SInt => "int64_t"
+        case _: DummySInt => "int64_t"
         case _: Float => "double"
         case _ => "uint64_t"
-        // case _ => throw new IllegalArgumentException(s"Data type $dataType is unknown")
       }
     }
 

--- a/src/main/scala/gemmini/LoadController.scala
+++ b/src/main/scala/gemmini/LoadController.scala
@@ -16,11 +16,11 @@ class LoadController[T <: Data, U <: Data, V <: Data](config: GemminiArrayConfig
   import config._
 
   val io = IO(new Bundle {
-    val cmd = Flipped(Decoupled(new GemminiCmd(rob_entries)))
+    val cmd = Flipped(Decoupled(new GemminiCmd(reservation_station_entries)))
 
     val dma = new ScratchpadReadMemIO(local_addr_t, mvin_scale_t_bits)
 
-    val completed = Decoupled(UInt(log2Up(rob_entries).W))
+    val completed = Decoupled(UInt(log2Up(reservation_station_entries).W))
 
     val busy = Output(Bool())
 
@@ -84,7 +84,7 @@ class LoadController[T <: Data, U <: Data, V <: Data](config: GemminiArrayConfig
   val nCmds = (max_in_flight_mem_reqs / block_rows) + 1
 
   val deps_t = new Bundle {
-    val rob_id = UInt(log2Up(rob_entries).W)
+    val rob_id = UInt(log2Up(reservation_station_entries).W)
   }
 
   val maxBytesInRowRequest = config.dma_maxbytes max (block_cols * config.inputType.getWidth / 8) max

--- a/src/main/scala/gemmini/MeshWithDelays.scala
+++ b/src/main/scala/gemmini/MeshWithDelays.scala
@@ -45,7 +45,7 @@ class MeshWithDelays[T <: Data: Arithmetic, U <: TagQueueTag with Data]
   assert(meshRows*tileRows == meshColumns*tileColumns)
   val block_size = meshRows*tileRows
 
-  val latency_per_pe = (tile_latency + 1).toFloat / (tileRows min tileColumns)
+  val latency_per_pe = ((tile_latency + 1).toFloat / (tileRows min tileColumns)) max 1.0f
   val max_simultaneous_matmuls = if (n_simultaneous_matmuls == -1) {
     (5 * latency_per_pe).ceil.toInt
   } else {

--- a/src/main/scala/gemmini/ReservationStation.scala
+++ b/src/main/scala/gemmini/ReservationStation.scala
@@ -13,37 +13,42 @@ import midas.targetutils.SynthesizePrintf
 
 
 // TODO unify this class with GemminiCmdWithDeps
-class ReservationStationIssue[T <: Data](cmd_t: T, rob_entries: Int) extends Bundle {
+class ReservationStationIssue[T <: Data](cmd_t: T, id_width: Int) extends Bundle {
   val valid = Output(Bool())
   val ready = Input(Bool())
   val cmd = Output(cmd_t.cloneType)
-  val rob_id = Output(UInt(log2Up(rob_entries).W))
+  val rob_id = Output(UInt(id_width.W))
 
   def fire(dummy: Int=0) = valid && ready
-
 }
 
 // TODO we don't need to store the full command in here. We should be able to release the command directly into the relevant controller and only store the associated metadata in the ROB. This would reduce the size considerably
-class ReservationStation[T <: Data : Arithmetic, U <: Data, V <: Data](config: GemminiArrayConfig[T, U, V], cmd_t: RoCCCommand) extends Module {
+class ReservationStation[T <: Data : Arithmetic, U <: Data, V <: Data](config: GemminiArrayConfig[T, U, V], cmd_t: GemminiCmd) extends Module {
   import config._
 
   val block_rows = tileRows * meshRows
   val block_cols = tileColumns * meshColumns
 
+  val max_instructions_completed_per_type_per_cycle = 2 // Every cycle, at most two instructions of a single "type" (ld/st/ex) can be completed: one through the io.completed port, and the other if it is a "complete-on-issue" instruction
+
   val io = IO(new Bundle {
     val alloc = Flipped(Decoupled(cmd_t.cloneType))
 
-    val completed = Flipped(Valid(UInt(log2Up(rob_entries).W)))
+    val completed = Flipped(Valid(UInt(ROB_ID_WIDTH.W)))
 
     val issue = new Bundle {
-      val ld = new ReservationStationIssue(cmd_t, rob_entries)
-      val st = new ReservationStationIssue(cmd_t, rob_entries)
-      val ex = new ReservationStationIssue(cmd_t, rob_entries)
+      val ld = new ReservationStationIssue(cmd_t, ROB_ID_WIDTH)
+      val st = new ReservationStationIssue(cmd_t, ROB_ID_WIDTH)
+      val ex = new ReservationStationIssue(cmd_t, ROB_ID_WIDTH)
     }
 
-    val ld_utilization = Output(UInt(log2Up(rob_entries+1).W))
-    val st_utilization = Output(UInt(log2Up(rob_entries+1).W))
-    val ex_utilization = Output(UInt(log2Up(rob_entries+1).W))
+    val conv_ld_completed = Output(UInt(log2Up(max_instructions_completed_per_type_per_cycle+1).W))
+    val conv_ex_completed = Output(UInt(log2Up(max_instructions_completed_per_type_per_cycle+1).W))
+    val conv_st_completed = Output(UInt(log2Up(max_instructions_completed_per_type_per_cycle+1).W))
+
+    val matmul_ld_completed = Output(UInt(log2Up(max_instructions_completed_per_type_per_cycle+1).W))
+    val matmul_ex_completed = Output(UInt(log2Up(max_instructions_completed_per_type_per_cycle+1).W))
+    val matmul_st_completed = Output(UInt(log2Up(max_instructions_completed_per_type_per_cycle+1).W))
 
     val busy = Output(Bool())
 
@@ -51,7 +56,7 @@ class ReservationStation[T <: Data : Arithmetic, U <: Data, V <: Data](config: G
   })
 
   // TODO make this a ChiselEnum
-  val ldq :: stq :: exq :: Nil = Enum(3)
+  val ldq :: exq :: stq :: Nil = Enum(3)
   val q_t = ldq.cloneType
 
   class OpT extends Bundle {
@@ -92,16 +97,34 @@ class ReservationStation[T <: Data : Arithmetic, U <: Data, V <: Data](config: G
 
     val cmd = cmd_t.cloneType
 
-    val deps = Vec(rob_entries, Bool())
-    def ready(dummy: Int = 0): Bool = !deps.reduce(_ || _)
+    // instead of one large deps vector, we need 3 separate ones if we want
+    // easy indexing, small area while allowing them to be different sizes
+    val deps_ld = Vec(reservation_station_entries_ld, Bool())
+    val deps_ex = Vec(reservation_station_entries_ex, Bool())
+    val deps_st = Vec(reservation_station_entries_st, Bool())
+
+    def ready(dummy: Int = 0): Bool = !(deps_ld.reduce(_ || _) || deps_ex.reduce(_ || _) || deps_st.reduce(_ || _))
 
     // Debugging signals
     val allocated_at = UInt(instructions_allocated.getWidth.W)
   }
-  val full_entries = Reg(Vec(reservation_station_full_entries, UDValid(new Entry)))
-  val partial_entries = Reg(Vec(reservation_station_partial_entries, UDValid(new Entry)))
 
-  val entries = full_entries ++ partial_entries
+  assert(isPow2(reservation_station_entries_ld))
+  assert(isPow2(reservation_station_entries_ex))
+  assert(isPow2(reservation_station_entries_st))
+
+  val entries_ld = Reg(Vec(reservation_station_entries_ld, UDValid(new Entry)))
+  val entries_ex = Reg(Vec(reservation_station_entries_ex, UDValid(new Entry)))
+  val entries_st = Reg(Vec(reservation_station_entries_st, UDValid(new Entry)))
+
+  val entries = entries_ld ++ entries_ex ++ entries_st
+
+  val empty_ld = !entries_ld.map(_.valid).reduce(_ || _)
+  val empty_ex = !entries_ex.map(_.valid).reduce(_ || _)
+  val empty_st = !entries_st.map(_.valid).reduce(_ || _)
+  val full_ld = entries_ld.map(_.valid).reduce(_ && _)
+  val full_ex = entries_ex.map(_.valid).reduce(_ && _)
+  val full_st = entries_st.map(_.valid).reduce(_ && _)
 
   val empty = !entries.map(_.valid).reduce(_ || _)
   val full = entries.map(_.valid).reduce(_ && _)
@@ -109,6 +132,31 @@ class ReservationStation[T <: Data : Arithmetic, U <: Data, V <: Data](config: G
   val utilization = PopCount(entries.map(e => e.valid)) // TODO it may be cheaper to count the utilization in a register, rather than performing a PopCount
   val solitary_preload = RegInit(false.B) // This checks whether or not the reservation station received a "preload" instruction, but hasn't yet received the following "compute" instruction
   io.busy := !empty && !(utilization === 1.U && solitary_preload)
+  
+  // Tell the conv and matmul FSMs if any of their issued instructions completed
+  val conv_ld_issue_completed = WireInit(false.B)
+  val conv_st_issue_completed = WireInit(false.B)
+  val conv_ex_issue_completed = WireInit(false.B)
+
+  val conv_ld_completed = WireInit(false.B)
+  val conv_st_completed = WireInit(false.B)
+  val conv_ex_completed = WireInit(false.B)
+
+  val matmul_ld_issue_completed = WireInit(false.B)
+  val matmul_st_issue_completed = WireInit(false.B)
+  val matmul_ex_issue_completed = WireInit(false.B)
+
+  val matmul_ld_completed = WireInit(false.B)
+  val matmul_st_completed = WireInit(false.B)
+  val matmul_ex_completed = WireInit(false.B)
+  
+  io.conv_ld_completed := conv_ld_issue_completed +& conv_ld_completed
+  io.conv_st_completed := conv_st_issue_completed +& conv_st_completed
+  io.conv_ex_completed := conv_ex_issue_completed +& conv_ex_completed
+
+  io.matmul_ld_completed := matmul_ld_issue_completed +& matmul_ld_completed
+  io.matmul_st_completed := matmul_st_issue_completed +& matmul_st_completed
+  io.matmul_ex_completed := matmul_ex_issue_completed +& matmul_ex_completed
 
   // Config values set by programmer
   val a_stride = Reg(UInt(a_stride_bits.W))
@@ -121,47 +169,27 @@ class ReservationStation[T <: Data : Arithmetic, U <: Data, V <: Data](config: G
 
   val new_entry = Wire(new Entry)
   new_entry := DontCare
-  val new_full_allocs = Wire(Vec(reservation_station_full_entries, Bool()))
-  new_full_allocs.foreach(_ := false.B)
-  val new_partial_allocs = Wire(Vec(reservation_station_partial_entries, Bool()))
-  new_partial_allocs.foreach(_ := false.B)
-  val new_entry_oh = new_full_allocs ++ new_partial_allocs
-  val alloc_fire = io.alloc.fire
 
-  val raws_probe = WireInit(0.U(rob_entries.W))
-  val waws_probe = WireInit(0.U(rob_entries.W))
-  val wars_probe = WireInit(0.U(rob_entries.W))
-  val older_in_same_q_probe = WireInit(0.U(rob_entries.W))
-  val is_st_and_must_wait_for_prior_ex_config_probe = WireInit(0.U(rob_entries.W))
-  val is_ex_config_and_must_wait_for_prior_st_probe = WireInit(0.U(rob_entries.W))
+  val new_allocs_oh_ld = Wire(Vec(reservation_station_entries_ld, Bool()))
+  val new_allocs_oh_ex = Wire(Vec(reservation_station_entries_ex, Bool()))
+  val new_allocs_oh_st = Wire(Vec(reservation_station_entries_st, Bool()))
 
-  val wars_op1_probe = WireInit(0.U(rob_entries.W))
-  val wars_op2_probe = WireInit(0.U(rob_entries.W))
-  val raws_op1_probe = WireInit(0.U(rob_entries.W))
-  val raws_op2_probe = WireInit(0.U(rob_entries.W))
+  val new_entry_oh = new_allocs_oh_ld ++ new_allocs_oh_ex ++ new_allocs_oh_st
+  new_entry_oh.foreach(_ := false.B)
 
-  dontTouch(raws_probe)
-  dontTouch(waws_probe)
-  dontTouch(wars_probe)
-  dontTouch(wars_op1_probe)
-  dontTouch(wars_op2_probe)
-  dontTouch(raws_op1_probe)
-  dontTouch(raws_op2_probe)
-  dontTouch(older_in_same_q_probe)
-  dontTouch(is_st_and_must_wait_for_prior_ex_config_probe)
-  dontTouch(is_ex_config_and_must_wait_for_prior_st_probe)
+  val alloc_fire = io.alloc.fire()
 
   dontTouch(new_entry)
   io.alloc.ready := false.B
   when (io.alloc.valid) {
     val spAddrBits = 32
-    val cmd = io.alloc.bits
+    val cmd = io.alloc.bits.cmd
     val funct = cmd.inst.funct
     val funct_is_compute = funct === COMPUTE_AND_STAY_CMD || funct === COMPUTE_AND_FLIP_CMD
     val config_cmd_type = cmd.rs1(1,0) // TODO magic numbers
 
     new_entry.issued := false.B
-    new_entry.cmd := cmd
+    new_entry.cmd := io.alloc.bits
 
     new_entry.is_config := funct === CONFIG_CMD
 
@@ -237,8 +265,8 @@ class ReservationStation[T <: Data : Arithmetic, U <: Data, V <: Data](config: G
       dst.bits.end := dst.bits.start + preload_rows
       dst.bits.wraps_around := dst.bits.start.add_with_overflow(preload_rows)._2
     }.otherwise {
-      val id = MuxCase(0.U, Seq((new_entry.cmd.inst.funct === LOAD2_CMD) -> 1.U,
-        (new_entry.cmd.inst.funct === LOAD3_CMD) -> 2.U))
+      val id = MuxCase(0.U, Seq((new_entry.cmd.cmd.inst.funct === LOAD2_CMD) -> 1.U,
+        (new_entry.cmd.cmd.inst.funct === LOAD3_CMD) -> 2.U))
       val block_stride = ld_block_strides(id)
       val pixel_repeats = ld_pixel_repeats(id)
 
@@ -276,108 +304,81 @@ class ReservationStation[T <: Data : Arithmetic, U <: Data, V <: Data](config: G
     ))
 
     assert(is_load || is_store || is_ex)
-    // This can be RAW op1/op2 <- dst, or WAW dst <- dst
-    val opa_matches_opa = VecInit(entries.map { e => e.valid && e.bits.opa.valid && new_entry.opa.bits.overlaps(e.bits.opa.bits) })
-    // This can be WAR dst <- op1/op2
-    val opa_matches_opb = VecInit(entries.map { e => e.valid && e.bits.opb.valid && new_entry.opa.bits.overlaps(e.bits.opb.bits) })
-    // This can be RAW op2 <- dst
-    val opb_matches_opa = VecInit(entries.map { e => e.valid && e.bits.opa.valid && new_entry.opb.bits.overlaps(e.bits.opa.bits) })
+    assert(ldq < exq && exq < stq)
 
-    val op1_matches_opa = VecInit((entries zip (opa_matches_opa zip opb_matches_opa)).map { case (e, (a, b)) =>
-      e.valid && op1.valid && Mux(dst.valid, b, a)
-    })
-    val op2_matches_opa = VecInit((entries zip (opa_matches_opa zip opb_matches_opa)).map { case (e, (a, b)) =>
-      e.valid && op2.valid && Mux(dst.valid || op1.valid, b, a)
-    })
-    val dst_matches_opa = VecInit((entries zip opa_matches_opa).map { case (e, a) =>
-      e.valid && dst.valid && a
-    })
-    val dst_matches_opb = VecInit((entries zip opa_matches_opb).map { case (e, b) =>
-      e.valid && dst.valid && b
-    })
+    val not_config = !new_entry.is_config
+    when (is_load) {
+      // war (after ex/st) | waw (after ex)
+      new_entry.deps_ld := VecInit(entries_ld.map { e => e.valid && !e.bits.issued }) // same q
 
-    val op1_raws_opa = VecInit((entries zip op1_matches_opa).map { case (e, m) =>
-      m && op1.valid && e.bits.q =/= new_entry.q && e.bits.opa_is_dst
-    })
-    val op2_raws_opa = VecInit((entries zip op2_matches_opa).map { case (e, m) =>
-      m && op2.valid && e.bits.q =/= new_entry.q && e.bits.opa_is_dst
-    })
-    val raws = VecInit((op1_raws_opa zip op2_raws_opa).map { case (a, b) => a || b })
+      new_entry.deps_ex := VecInit(entries_ex.map { e => e.valid && !new_entry.is_config && (
+        (new_entry.opa.bits.overlaps(e.bits.opa.bits) && e.bits.opa.valid) || // waw if preload, war if compute
+        (new_entry.opa.bits.overlaps(e.bits.opb.bits) && e.bits.opb.valid))}) // war
 
-    val dst_wars_opa = VecInit((entries zip dst_matches_opa).map { case (e, m) =>
-      m && dst.valid && e.bits.q =/= new_entry.q && !e.bits.opa_is_dst
-    })
-    val dst_wars_opb = VecInit((entries zip dst_matches_opb).map { case (e, m) =>
-      m && dst.valid && e.bits.q =/= new_entry.q
-    })
-    val wars = VecInit((dst_wars_opa zip dst_wars_opb).map { case (a, b) => a || b })
+      new_entry.deps_st := VecInit(entries_st.map { e => e.valid && e.bits.opa.valid && not_config &&
+        new_entry.opa.bits.overlaps(e.bits.opa.bits)})  // war
+    }.elsewhen (is_ex) {
+      // raw (after ld) | war (after st) | waw (after ld)
+      new_entry.deps_ld := VecInit(entries_ld.map { e => e.valid && e.bits.opa.valid && not_config && (
+        new_entry.opa.bits.overlaps(e.bits.opa.bits) || // waw if preload, raw if compute
+        new_entry.opb.bits.overlaps(e.bits.opa.bits))}) // raw
 
-    val dst_waws_opa = VecInit((entries zip dst_matches_opa).map { case (e, m) =>
-      m && dst.valid && (e.bits.q =/= new_entry.q || new_entry.q === ldq) && e.bits.opa_is_dst
-    })
-    val waws = dst_waws_opa
+      new_entry.deps_ex := VecInit(entries_ex.map { e => e.valid && !e.bits.issued }) // same q
 
-    val older_in_same_q = VecInit(entries.map { e =>
-      e.valid && e.bits.q === new_entry.q && !e.bits.issued
-    })
+      new_entry.deps_st := VecInit(entries_st.map { e => e.valid && e.bits.opa.valid && not_config && new_entry.opa_is_dst &&
+        new_entry.opa.bits.overlaps(e.bits.opa.bits)})  // war
+    }.otherwise {
+      // raw (after ld/ex)
+      new_entry.deps_ld := VecInit(entries_ld.map { e => e.valid && e.bits.opa.valid && not_config &&
+        new_entry.opa.bits.overlaps(e.bits.opa.bits)})  // raw
 
-    val is_st_and_must_wait_for_prior_ex_config = VecInit(entries.map { e =>
-      e.valid && new_entry.q === stq && !new_entry.is_config && e.bits.q === exq && e.bits.is_config
-    })
+      new_entry.deps_ex := VecInit(entries_ex.map { e => e.valid && e.bits.opa.valid && not_config &&
+        e.bits.opa_is_dst && new_entry.opa.bits.overlaps(e.bits.opa.bits)}) // raw only if ex is preload
 
-    val is_ex_config_and_must_wait_for_prior_st = VecInit(entries.map { e =>
-      // TODO when acc reads no longer rely upon config-ex's relu6, this dependency can be broken
-      e.valid && new_entry.q === exq && new_entry.is_config && e.bits.q === stq && !e.bits.is_config
-    })
-
-    new_entry.deps := (Cat(raws) | Cat(wars) | Cat(waws) | Cat(older_in_same_q) |
-      Cat(is_st_and_must_wait_for_prior_ex_config) | Cat(is_ex_config_and_must_wait_for_prior_st)).asBools().reverse
-
-    raws_probe := Cat(raws.reverse)
-    waws_probe := Cat(waws.reverse)
-    wars_probe := Cat(wars.reverse)
-    older_in_same_q_probe := Cat(older_in_same_q.reverse)
-    is_st_and_must_wait_for_prior_ex_config_probe := Cat(is_st_and_must_wait_for_prior_ex_config.reverse)
-    is_ex_config_and_must_wait_for_prior_st_probe := Cat(is_ex_config_and_must_wait_for_prior_st.reverse)
+      new_entry.deps_st := VecInit(entries_st.map { e => e.valid && !e.bits.issued }) // same q
+    }
 
     new_entry.allocated_at := instructions_allocated
 
     new_entry.complete_on_issue := new_entry.is_config && new_entry.q =/= exq
 
-    val is_full = PopCount(Seq(dst.valid, op1.valid, op2.valid)) > 1.U
-    val full_alloc_id = MuxCase((reservation_station_full_entries-1).U, full_entries.zipWithIndex.map { case (e, i) => !e.valid -> i.U })
-    val partial_alloc_id = MuxCase((reservation_station_partial_entries-1).U, partial_entries.zipWithIndex.map { case (e, i) => !e.valid -> i.U })
+    Seq(
+      (ldq, entries_ld, new_allocs_oh_ld, reservation_station_entries_ld),
+      (exq, entries_ex, new_allocs_oh_ex, reservation_station_entries_ex),
+      (stq, entries_st, new_allocs_oh_st, reservation_station_entries_st))
+      .foreach { case (q, entries_type, new_allocs_type, entries_count) =>
+        when (new_entry.q === q) {
+          val is_full = PopCount(Seq(dst.valid, op1.valid, op2.valid)) > 1.U
+          when (q =/= exq) { assert(!is_full) }
 
-    when (!is_full && !partial_entries(partial_alloc_id).valid) {
-      io.alloc.ready := true.B
-      partial_entries(partial_alloc_id).valid := true.B
-      partial_entries(partial_alloc_id).bits := new_entry
-      partial_entries(partial_alloc_id).bits.opb.valid := false.B
-      partial_entries(partial_alloc_id).bits.opb.bits := DontCare
-      new_partial_allocs(partial_alloc_id) := true.B
-    } .elsewhen (!full_entries(full_alloc_id).valid) {
-      io.alloc.ready := true.B
-      full_entries(full_alloc_id).valid := true.B
-      full_entries(full_alloc_id).bits := new_entry
-      new_full_allocs(full_alloc_id) := true.B
-    }
+          // looking for the first invalid entry
+          val alloc_id = MuxCase((entries_count - 1).U, entries_type.zipWithIndex.map { case (e, i) => !e.valid -> i.U })
+
+          when (!entries_type(alloc_id).valid) {
+            io.alloc.ready := true.B
+            entries_type(alloc_id).valid := true.B
+            entries_type(alloc_id).bits := new_entry
+            new_allocs_type(alloc_id) := true.B
+          }
+        }
+      }
 
     when (io.alloc.fire) {
       when (new_entry.is_config && new_entry.q === exq && !is_im2col) {
-        a_stride := new_entry.cmd.rs1(31, 16) // TODO magic numbers // TODO this needs to be kept in sync with ExecuteController.scala
-        c_stride := new_entry.cmd.rs2(63, 48) // TODO magic numbers // TODO this needs to be kept in sync with ExecuteController.scala
-        val set_only_strides = new_entry.cmd.rs1(7) // TODO magic numbers
+        a_stride := new_entry.cmd.cmd.rs1(31, 16) // TODO magic numbers // TODO this needs to be kept in sync with ExecuteController.scala
+        c_stride := new_entry.cmd.cmd.rs2(63, 48) // TODO magic numbers // TODO this needs to be kept in sync with ExecuteController.scala
+        val set_only_strides = new_entry.cmd.cmd.rs1(7) // TODO magic numbers
         when (!set_only_strides) {
-          a_transpose := new_entry.cmd.rs1(8) // TODO magic numbers
+          a_transpose := new_entry.cmd.cmd.rs1(8) // TODO magic numbers
         }
       }.elsewhen(new_entry.is_config && new_entry.q === ldq) {
-        val id = new_entry.cmd.rs1(4,3) // TODO magic numbers
-        val block_stride = new_entry.cmd.rs1(31, 16) // TODO magic numbers
-        val repeat_pixels = maxOf(new_entry.cmd.rs1(8 + pixel_repeats_bits - 1, 8), 1.U) // TODO we use a default value of pixel repeats here, for backwards compatibility. However, we should deprecate and remove this default value eventually
+        val id = new_entry.cmd.cmd.rs1(4,3) // TODO magic numbers
+        val block_stride = new_entry.cmd.cmd.rs1(31, 16) // TODO magic numbers
+        val repeat_pixels = maxOf(new_entry.cmd.cmd.rs1(8 + pixel_repeats_bits - 1, 8), 1.U) // TODO we use a default value of pixel repeats here, for backwards compatibility. However, we should deprecate and remove this default value eventually
         ld_block_strides(id) := block_stride
         ld_pixel_repeats(id) := repeat_pixels - 1.U
       }.elsewhen(new_entry.is_config && new_entry.q === stq) {
-        val pool_stride = new_entry.cmd.rs1(5, 4) // TODO magic numbers
+        val pool_stride = new_entry.cmd.cmd.rs1(5, 4) // TODO magic numbers
         pooling_is_enabled := pool_stride =/= 0.U
       }.elsewhen(funct === PRELOAD_CMD) {
         solitary_preload := true.B
@@ -388,45 +389,105 @@ class ReservationStation[T <: Data : Arithmetic, U <: Data, V <: Data](config: G
   }
 
   // Issue commands which are ready to be issued
-  Seq((ldq, io.issue.ld), (stq, io.issue.st), (exq, io.issue.ex)).foreach { case (q, io) =>
-    val issue_valids = entries.map(e => e.valid && e.bits.ready() && !e.bits.issued && e.bits.q === q)
+  Seq((ldq, io.issue.ld, entries_ld), (exq, io.issue.ex, entries_ex), (stq, io.issue.st, entries_st))
+    .foreach { case (q, io, entries_type) =>
+
+    val issue_valids = entries_type.map(e => e.valid && e.bits.ready() && !e.bits.issued)
     val issue_sel = PriorityEncoderOH(issue_valids)
     val issue_id = OHToUInt(issue_sel)
-    val issue_entry = Mux1H(issue_sel, entries)
+    val global_issue_id = Cat(q.asUInt, issue_id.pad(log2Up(res_max_per_type)))
+    assert(q.getWidth == 2)
+    assert(global_issue_id.getWidth == 2 + log2Up(res_max_per_type))
+
+    val issue_entry = Mux1H(issue_sel, entries_type)
 
     io.valid := issue_valids.reduce(_||_)
     io.cmd := issue_entry.bits.cmd
-    io.rob_id := OHToUInt(issue_sel)
+    // use the most significant 2 bits to indicate instruction type
+    io.rob_id := global_issue_id
+
+    val complete_on_issue = entries_type(issue_id).bits.complete_on_issue
+    val from_conv_fsm = entries_type(issue_id).bits.cmd.from_conv_fsm
+    val from_matmul_fsm = entries_type(issue_id).bits.cmd.from_matmul_fsm
 
     when (io.fire()) {
-      // Clear out all the dependency bits for instructions which depend on the same queue
-      entries.zipWithIndex.foreach { case (e, i) =>
-        val is_same_q = Mux(alloc_fire && new_entry_oh(i),
-          new_entry.q === issue_entry.bits.q,
-          e.bits.q === issue_entry.bits.q)
-
-        when (is_same_q || issue_entry.bits.complete_on_issue) {
-          e.bits.deps(issue_id) := false.B
-        }
-      }
-      for ((e, i) <- entries.zipWithIndex) {
+      entries_type.zipWithIndex.foreach { case (e, i) =>
         when (issue_sel(i)) {
           e.bits.issued := true.B
           e.valid := !e.bits.complete_on_issue
         }
       }
+
+      // Update the "deps" vectors of all instructions which depend on the one that is being issued
+      Seq((ldq, entries_ld), (exq, entries_ex), (stq, entries_st))
+        .foreach { case (q_, entries_type_) =>
+
+        entries_type_.zipWithIndex.foreach { case (e, i) =>
+          val deps_type = if (q == ldq) e.bits.deps_ld
+                          else if (q == exq) e.bits.deps_ex else e.bits.deps_st
+          when (q === q_) {
+            deps_type(issue_id) := false.B
+          }.otherwise {
+            when (issue_entry.bits.complete_on_issue) {
+              deps_type(issue_id) := false.B
+            }
+          }
+        }
+      }
+
+      // If the instruction completed on issue, then notify the conv/matmul FSMs that another one of their commands
+      // completed
+      when (q === ldq) { conv_ld_issue_completed := complete_on_issue && from_conv_fsm }
+      when (q === stq) { conv_st_issue_completed := complete_on_issue && from_conv_fsm }
+      when (q === exq) { conv_ex_issue_completed := complete_on_issue && from_conv_fsm }
+
+      when (q === ldq) { matmul_ld_issue_completed := complete_on_issue && from_matmul_fsm }
+      when (q === stq) { matmul_st_issue_completed := complete_on_issue && from_matmul_fsm }
+      when (q === exq) { matmul_ex_issue_completed := complete_on_issue && from_matmul_fsm }
     }
   }
 
   // Mark entries as completed once they've returned
   when (io.completed.fire) {
-    entries.foreach(_.bits.deps(io.completed.bits) := false.B)
+    val type_width = log2Up(res_max_per_type)
+    val queue_type = io.completed.bits(type_width + 1, type_width)
+    val issue_id = io.completed.bits(type_width - 1, 0)
 
-    for ((e, i) <- entries.zipWithIndex) {
-      when (i.U === io.completed.bits) {
-        e.valid := false.B
-        assert(e.valid)
-      }
+    when (queue_type === ldq) {
+      entries.foreach(_.bits.deps_ld(issue_id) := false.B)
+      entries_ld(issue_id).valid := false.B
+
+      conv_ld_completed := entries_ld(issue_id).bits.cmd.from_conv_fsm
+      matmul_ld_completed := entries_ld(issue_id).bits.cmd.from_matmul_fsm
+
+      assert(entries_ld(issue_id).valid)
+    }.elsewhen (queue_type === exq) {
+      entries.foreach(_.bits.deps_ex(issue_id) := false.B)
+      entries_ex(issue_id).valid := false.B
+
+      conv_ex_completed := entries_ex(issue_id).bits.cmd.from_conv_fsm
+      matmul_ex_completed := entries_ex(issue_id).bits.cmd.from_matmul_fsm
+      
+      assert(entries_ex(issue_id).valid)
+    }.elsewhen (queue_type === stq) {
+      entries.foreach(_.bits.deps_st(issue_id) := false.B)
+      entries_st(issue_id).valid := false.B
+
+      conv_st_completed := entries_st(issue_id).bits.cmd.from_conv_fsm
+      matmul_st_completed := entries_st(issue_id).bits.cmd.from_matmul_fsm
+      
+      assert(entries_st(issue_id).valid)
+    }.otherwise {
+      assert(queue_type =/= 3.U)
+    }
+  }
+
+  // Explicitly mark "opb" in all ld/st queues entries as being invalid.
+  // This helps us to reduce the total reservation table area
+  Seq(entries_ld, entries_st).foreach { entries_type =>
+    entries_type.foreach { e =>
+      e.bits.opb.valid := false.B
+      e.bits.opb.bits := DontCare
     }
   }
 
@@ -434,25 +495,23 @@ class ReservationStation[T <: Data : Arithmetic, U <: Data, V <: Data](config: G
   val utilization_ld_q_unissued = PopCount(entries.map(e => e.valid && !e.bits.issued && e.bits.q === ldq))
   val utilization_st_q_unissued = PopCount(entries.map(e => e.valid && !e.bits.issued && e.bits.q === stq))
   val utilization_ex_q_unissued = PopCount(entries.map(e => e.valid && !e.bits.issued && e.bits.q === exq))
-  val utilization_ld_q = PopCount(entries.map(e => e.valid && e.bits.q === ldq))
-  val utilization_st_q = PopCount(entries.map(e => e.valid && e.bits.q === stq))
-  val utilization_ex_q = PopCount(entries.map(e => e.valid && e.bits.q === exq))
-
-  io.ld_utilization := utilization_ld_q
-  io.st_utilization := utilization_st_q
-  io.ex_utilization := utilization_ex_q
+  val utilization_ld_q = PopCount(entries_ld.map(e => e.valid))
+  val utilization_st_q = PopCount(entries_st.map(e => e.valid))
+  val utilization_ex_q = PopCount(entries_ex.map(e => e.valid))
 
   val valids = VecInit(entries.map(_.valid))
-  val functs = VecInit(entries.map(_.bits.cmd.inst.funct))
+  val functs = VecInit(entries.map(_.bits.cmd.cmd.inst.funct))
   val issueds = VecInit(entries.map(_.bits.issued))
-  val packed_deps = VecInit(entries.map(e => Cat(e.bits.deps.reverse)))
+  val packed_deps = VecInit(entries.map(e =>
+    Cat(Cat(e.bits.deps_ld.reverse), Cat(e.bits.deps_ex.reverse), Cat(e.bits.deps_st.reverse))))
 
   dontTouch(valids)
   dontTouch(functs)
   dontTouch(issueds)
   dontTouch(packed_deps)
 
-  val pop_count_packed_deps = VecInit(entries.map(e => Mux(e.valid, PopCount(e.bits.deps), 0.U)))
+  val pop_count_packed_deps = VecInit(entries.map(e => Mux(e.valid,
+    PopCount(e.bits.deps_ld) + PopCount(e.bits.deps_ex) + PopCount(e.bits.deps_st), 0.U)))
   val min_pop_count = pop_count_packed_deps.reduce((acc, d) => minOf(acc, d))
   // assert(min_pop_count < 2.U)
   dontTouch(pop_count_packed_deps)

--- a/src/main/scala/gemmini/StoreController.scala
+++ b/src/main/scala/gemmini/StoreController.scala
@@ -16,11 +16,11 @@ class StoreController[T <: Data : Arithmetic, U <: Data, V <: Data](config: Gemm
   import config._
 
   val io = IO(new Bundle {
-    val cmd = Flipped(Decoupled(new GemminiCmd(rob_entries)))
+    val cmd = Flipped(Decoupled(new GemminiCmd(reservation_station_entries)))
 
     val dma = new ScratchpadWriteMemIO(local_addr_t, acc_scale_t_bits)
 
-    val completed = Decoupled(UInt(log2Up(rob_entries).W))
+    val completed = Decoupled(UInt(log2Up(reservation_station_entries).W))
 
     val busy = Output(Bool())
 
@@ -122,7 +122,7 @@ class StoreController[T <: Data : Arithmetic, U <: Data, V <: Data](config: Gemm
   val nCmds = (max_in_flight_mem_reqs / block_rows) + 1
 
   val deps_t = new Bundle {
-    val rob_id = UInt(log2Up(rob_entries).W)
+    val rob_id = UInt(log2Up(reservation_station_entries).W)
   }
 
   val cmd_tracker_max_rows = ((block_rows * max_blocks) max

--- a/src/main/scala/gemmini/TransposePreloadUnroller.scala
+++ b/src/main/scala/gemmini/TransposePreloadUnroller.scala
@@ -13,8 +13,8 @@ class TransposePreloadUnroller[T <: Data, U <: Data, V <: Data](config: GemminiA
   import GemminiISA._
 
   val io = IO(new Bundle {
-    val in = Flipped(Decoupled(new GemminiCmd(rob_entries)))
-    val out = Decoupled(new GemminiCmd(rob_entries))
+    val in = Flipped(Decoupled(new GemminiCmd(reservation_station_entries)))
+    val out = Decoupled(new GemminiCmd(reservation_station_entries))
     val counter = new CounterEventIO()
   })
 


### PR DESCRIPTION
New features:
* Add support for new "dummy configs" which give cycle-accurate performance results, but which don't guarantee functional correctness of matmul/conv operations
* Optimize area for reservation stations by splitting unified reservation station into separate stations for each instruction type

Bug fixes:
* Fix incorrect assertions from firing when building some non-systolic configs
* Fix unpredictable infinite stall caused by OS interrupts
* Fix build scripts when building simulators that can generate waveforms