### PR TITLE
Add smoke test | Support Gemmini spike

### DIFF
--- a/software/gemmini-ort.json
+++ b/software/gemmini-ort.json
@@ -53,6 +53,6 @@
   ],
   "overlay": "../onnxruntime-riscv/systolic_runner/imagenet_runner",
   "rootfs-size": "16GiB",
-  "run": "run-ort.sh"
+  "run": "run-ort.sh",
+  "spike-args": "--extension=gemmini"
 }
-

--- a/software/gemmini-smoke.json
+++ b/software/gemmini-smoke.json
@@ -1,9 +1,10 @@
 {
-  "name" : "gemmini-tests-interactive",
+  "name" : "gemmini-smoke",
   "workdir" : ".",
   "base" : "br-base.json",
   "overlay" : "overlay",
   "host-init" : "host-init.sh",
+  "command": "/root/run-test-smoke.sh",
   "rootfs-size" : "16GiB",
-  "spike-args": "--extension=gemmini"
+  "spike-args" : "--extension=gemmini"
 }

--- a/software/gemmini-tests-full.json
+++ b/software/gemmini-tests-full.json
@@ -4,5 +4,6 @@
   "base" : "br-base.json",
   "overlay" : "overlay",
   "host-init" : "host-init.sh",
-  "command": "/root/run-tests-full.sh"
+  "command": "/root/run-tests-full.sh",
+  "spike-args": "--extension=gemmini"
 }

--- a/software/gemmini-tests.json
+++ b/software/gemmini-tests.json
@@ -5,5 +5,6 @@
   "overlay" : "overlay",
   "host-init" : "host-init.sh",
   "command": "/root/run-tests.sh",
-  "rootfs-size" : "16GiB"
+  "rootfs-size" : "16GiB",
+  "spike-args" : "--extension=gemmini"
 }

--- a/software/overlay/root/run-test-smoke.sh
+++ b/software/overlay/root/run-test-smoke.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo "*****************TEST RESULTS*************" > test_output.txt
+
+echo "========mobilenet========="
+/root/imagenet/mobilenet-linux >> test_output.txt
+
+cat test_output.txt
+poweroff -f


### PR DESCRIPTION
- Adds `gemmini-smoke.json`, a smoke test to make sure that Linux + Gemmini works (used in Chipyard CI)
- Adds `spike-args` to all workloads so that they can use the `gemmini` extension in Spike when running `launch`.