### PR TITLE
fix CRITICAL overflow and underflow issue in PE.scala 

### DIFF
--- a/src/main/scala/gemmini/PE.scala
+++ b/src/main/scala/gemmini/PE.scala
@@ -11,12 +11,12 @@ class PEControl[T <: Data : Arithmetic](accType: T) extends Bundle {
 
 }
 
-class MacUnit[T <: Data](inputType: T, cType: T, dType: T) (implicit ev: Arithmetic[T]) extends Module {
+class MacUnit[T <: Data](inputType: T, dType: T) (implicit ev: Arithmetic[T]) extends Module {
   import ev._
   val io = IO(new Bundle {
     val in_a  = Input(inputType)
     val in_b  = Input(inputType)
-    val in_c  = Input(cType)
+    val in_c  = Input(dType)
     val out_d = Output(dType)
   })
 
@@ -61,7 +61,7 @@ class PE[T <: Data](inputType: T, outputType: T, accType: T, df: Dataflow.Value,
   // elaboration/synthesis tools often fail to consolidate and de-duplicate
   // MAC units. To force mac circuitry to be re-used, we create a "mac_unit"
   // module here which just performs a single MAC operation
-  val mac_unit = Module(new MacUnit(inputType, cType, outputType))
+  val mac_unit = Module(new MacUnit(inputType, outputType))
 
   val a  = io.in_a
   val b  = io.in_b


### PR DESCRIPTION
I have found that MacUnit implemented on pull #265 causes overflows and underflows inside the mesh when the supported dataflow of gemmini is `dataflow=Dataflow.WS`.
This issue does not occur when the supported dataflow is `dataflow=Dataflow.BOTH`.
The cause is as follows:


The bitwidth of `MacUnit.io.in_c` is set to `cType` when the `dataflow=Dataflow.WS`, 
where `val cType = if (df == Dataflow.WS) inputType else accType`.

`MacUnit.io.in_c` is the "Partial Sum (from PE above)" of the PE. This net needs width equal to be `accType` of gemmini, 
in order to prevent overflows and underflows of partial sums.
![img](https://github.com/ucb-bar/gemmini/raw/master/img/gemmini-systolic-array.png)

So I have changed the width of `MacUnit.io.in_c` to be same as `accType`.


And another interesting observation was that, built-in baremetal examples of matmul usually had no issues with the faulty code. This was because the random inputs and weight of the baremetal codes had too small absolute values to cause any overflows or underflows.


I suggest improving the random number generation of the baremetal codes a bit.