### PR TITLE
Fix deadlock in the DMA read pipeline

### DIFF
--- a/src/main/scala/gemmini/Scratchpad.scala
+++ b/src/main/scala/gemmini/Scratchpad.scala
@@ -499,7 +499,7 @@ class Scratchpad[T <: Data, U <: Data, V <: Data](config: GemminiArrayConfig[T, 
         bio.read.resp.ready := Mux(bio.read.resp.bits.fromDMA, dma_read_resp.ready, ex_read_resp.ready)
 
         dma_read_pipe.ready := writer.module.io.req.ready &&
-          !write_issue_q.io.deq.bits.laddr.is_acc_addr && write_issue_q.io.deq.bits.laddr.sp_bank() === i.U && // I believe we don't need to check that write_issue_q is valid here, because if the SRAM's resp is valid, then that means that the write_issue_q's deq should also be valid
+          ((!write_issue_q.io.deq.bits.laddr.is_acc_addr && write_issue_q.io.deq.bits.laddr.sp_bank() === i.U) && write_issue_q.io.deq.valid) &&
           !write_issue_q.io.deq.bits.laddr.is_garbage()
         when (dma_read_pipe.fire) {
           writeData.valid := true.B


### PR DESCRIPTION
When the `write_issue_q` dequeue is not valid, the random `.bits` may still indicate it is an acc address or may have its garbage bit set. This will erroneously cause the read pipeline output ready to go low, which combinationally causes the SRAM read response interface to deassert ready. As a result, there is a cycle of stalling reading from the SRAMs; however, writeData.valid does not accommodate this stall as it expects a continuous stream of data. This leads to the write queues with one extra data element not dequeued properly every once in a while, which fills up over time and leads to a deadlock. The fix gates the random bits with the `write_issue_q` output valid.