### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,6 @@ cd generators/gemmini
 make -C software/libgemmini install
 ```
 
-Setting Up Gemmini
-------------------
-
-Run the steps below to set up Gemmini configuration files, symlinks, and subdirectories:
-
-```shell
-cd chipyard/generators/gemmini
-./scripts/setup-paths.sh
-```
 
 Building Gemmini Software
 -------------------------
@@ -81,24 +72,17 @@ Building Gemmini Hardware and Cycle-Accurate Simulators
 Run the instructions below to build a cycle-accurate Gemmini simulator using Verilator.
 
 ```shell
-cd chipyard/generators/gemmini
-./scripts/build-verilator.sh
+cd chipyard/sims/verilator
+make CONFIG=GemminiRocketConfig
 
 # Or, if you want a simulator that can generate waveforms, run this:
-# ./scripts/build-verilator.sh --debug
+make debug CONFIG=GemminiRocketConfig
 ```
 
 After running this, in addition to the cycle-accurate simulator, you will be able to find the Verilog description of your SoC in `generated-src/`.
 
-Building Gemmini Functional Simulators
+Using Gemmini Functional Simulators
 ---------------------------
-
-Run the instructions below to build a functional ISA simulator for Gemmini (called "Spike").
-
-```shell
-cd chipyard/generators/gemmini
-./scripts/build-spike.sh
-```
 
 Spike typically runs _much_ faster than cycle-accurate simulators like Verilator or VCS.
 However, Spike can only verify functional correctness; it cannot give accurate performance metrics or profiling information.
@@ -109,19 +93,16 @@ Run Simulators
 Run the instructions below to run the Gemmini RISCV binaries that we built previously, using the simulators that we built above:
 
 ```shell
-cd chipyard/generators/gemmini
+cd chipyard/sims/verilator
 
 # Run a large DNN workload in the functional simulator
-./scripts/run-spike.sh resnet50
+spike --extension=gemmini pk ../../generators/gemmini/software/gemmini-rocc-tests/build/imagenet/resnet50-pk
+
+# Run a small DNN workload in the functional simulator
+spike --extension=gemmini ../../generators/gemmini/software/gemmini-rocc-tests/build/imagenet/resnet50-baremetal
 
 # Run a smaller workload in baremetal mode, on a cycle-accurate simulator
-./scripts/run-verilator.sh template
-
-# Run a smaller workload with the proxy-kernel, on a cycle accurate simulator
-./scripts/run-verilator.sh --pk template
-
-# Or, if you want to generate waveforms in `waveforms/`:
-# ./scripts/run-verilator.sh --pk --debug template
+make CONFIG=GemminiRocketConfig run-binary BINARY=../../generators/gemmini/software/gemmini-rocc-tests/build/baremetalC/template-baremetal
 ```
 
 Next steps


### PR DESCRIPTION
Updates gemmini's outdated README.

The script-based flows are unmaintained and tend to break. This exposes chipyard commands directly to the user instead.